### PR TITLE
[feat/#3] /export - 개인 집중 기록 내보내기

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -1,0 +1,143 @@
+/**
+ * /export 커맨드 핸들러
+ * 개인 집중 기록 내보내기
+ */
+
+import type { Session } from '../types';
+import { replyEphemeral } from '../utils/slack';
+import { formatDuration, formatTime } from '../utils/format';
+import { getDateRange } from '../utils/date';
+
+/** /export 핸들러 */
+export async function handleExport(env: Env, teamId: string, userId: string, text: string): Promise<Response> {
+	// 인자 파싱
+	const args = text.split(' ').filter((a) => a.trim());
+
+	// 인자 없으면 이번 주 기본
+	if (args.length === 0) {
+		const { startDate, endDate, label } = getDateRange('thisweek');
+		return generateExportText(env, teamId, userId, startDate, endDate, label);
+	}
+
+	// 단일 인자: 기간 키워드
+	if (args.length === 1) {
+		const period = args[0].toLowerCase();
+		if (['thisweek', 'lastweek', 'thismonth', 'lastmonth'].includes(period)) {
+			const { startDate, endDate, label } = getDateRange(period);
+			return generateExportText(env, teamId, userId, startDate, endDate, label);
+		}
+		return replyEphemeral(getUsageMessage());
+	}
+
+	// 두 인자: 날짜 범위
+	if (args.length === 2) {
+		const startInput = args[0];
+		const endInput = args[1];
+
+		// YY-MM-DD 형식 체크
+		if (!/^\d{2}-\d{2}-\d{2}$/.test(startInput) || !/^\d{2}-\d{2}-\d{2}$/.test(endInput)) {
+			return replyEphemeral(getUsageMessage());
+		}
+
+		const startDate = '20' + startInput;
+		const endDate = '20' + endInput;
+		const label = `${startInput} ~ ${endInput}`;
+		return generateExportText(env, teamId, userId, startDate, endDate, label);
+	}
+
+	return replyEphemeral(getUsageMessage());
+}
+
+/** 사용법 메시지 */
+function getUsageMessage(): string {
+	return (
+		`:fairy-chart: */export 사용법*\n\n` +
+		`• \`/export\` - 이번 주 (기본)\n` +
+		`• \`/export thisweek\` - 이번 주\n` +
+		`• \`/export lastweek\` - 지난 주\n` +
+		`• \`/export thismonth\` - 이번 달\n` +
+		`• \`/export 26-01-01 26-01-15\` - 특정 기간`
+	);
+}
+
+/** 텍스트 형식으로 기록 출력 */
+async function generateExportText(
+	env: Env,
+	teamId: string,
+	userId: string,
+	startDate: string,
+	endDate: string,
+	label: string
+): Promise<Response> {
+	// 해당 기간의 세션 수집
+	const sessions: Array<Session & { date: string }> = [];
+
+	let current = new Date(startDate + 'T00:00:00Z');
+	const end = new Date(endDate + 'T00:00:00Z');
+
+	while (current <= end) {
+		const dateKey = current.toISOString().split('T')[0];
+		const daySessions: Session[] = JSON.parse((await env.STUDY_KV.get(`${teamId}:sessions:${dateKey}`)) || '[]');
+
+		// 본인 세션만 필터링
+		const mySessions = daySessions.filter((s) => s.userId === userId);
+		for (const session of mySessions) {
+			sessions.push({ ...session, date: dateKey });
+		}
+
+		current.setUTCDate(current.getUTCDate() + 1);
+	}
+
+	// 세션이 없으면
+	if (sessions.length === 0) {
+		return replyEphemeral(`:fairy-chart: *${label}* 기간에 기록이 없어요!\n\n요정이 기다리고 있을게요 :fairy-wand:`);
+	}
+
+	// 시간순 정렬
+	sessions.sort((a, b) => a.start - b.start);
+
+	// 날짜별로 그룹핑
+	const byDate: Record<string, Array<Session & { date: string }>> = {};
+	for (const session of sessions) {
+		if (!byDate[session.date]) {
+			byDate[session.date] = [];
+		}
+		byDate[session.date].push(session);
+	}
+
+	// 텍스트 생성
+	const lines: string[] = [];
+	const dayNames = ['일', '월', '화', '수', '목', '금', '토'];
+
+	for (const [date, daySessions] of Object.entries(byDate)) {
+		const d = new Date(date + 'T00:00:00Z');
+		const dayName = dayNames[d.getUTCDay()];
+		const dateLabel = `${d.getUTCMonth() + 1}/${d.getUTCDate()} (${dayName})`;
+
+		for (const session of daySessions) {
+			const startTime = formatTimeShort(session.start);
+			const endTime = formatTimeShort(session.end);
+			const duration = formatDuration(session.duration);
+			lines.push(`${dateLabel} ${startTime}~${endTime} (${duration})`);
+		}
+	}
+
+	// 총계
+	const totalDuration = sessions.reduce((sum, s) => sum + s.duration, 0);
+
+	const message =
+		`:fairy-chart: *${label} 집중 기록*\n\n` +
+		`${lines.join('\n')}\n\n` +
+		`총 ${sessions.length}개 세션 | :fairy-hourglass: 합계 ${formatDuration(totalDuration)}`;
+
+	return replyEphemeral(message);
+}
+
+/** 시간만 짧게 포맷 (HH:MM) */
+function formatTimeShort(ts: number): string {
+	const d = new Date(ts + 9 * 60 * 60 * 1000); // KST
+	const h = d.getUTCHours().toString().padStart(2, '0');
+	const m = d.getUTCMinutes().toString().padStart(2, '0');
+	return `${h}:${m}`;
+}
+

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -7,3 +7,4 @@ export { handleEnd } from './end';
 export { handleMyStats } from './mystats';
 export { handleToday } from './today';
 export { handleWeekly, handleReportCommand } from './report';
+export { handleExport } from './export';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
  * 8명 스터디 그룹을 위한 집중 시간 기록 봇
  */
 
-import { handleStart, handleEnd, handleMyStats, handleToday, handleWeekly, handleReportCommand } from './commands';
+import { handleStart, handleEnd, handleMyStats, handleToday, handleWeekly, handleReportCommand, handleExport } from './commands';
 import { reply } from './utils/slack';
 
 export default {
@@ -41,6 +41,8 @@ export default {
 				return handleToday(env, teamId);
 			case '/report':
 				return handleReportCommand(env, teamId, userId, channelId, text);
+			case '/export':
+				return handleExport(env, teamId, userId, text);
 			default:
 				return reply('알 수 없는 명령어예요.');
 		}


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #3

## 📝 변경 사항
- `/export` 커맨드 핸들러 추가
- 기간 키워드 지원 (thisweek, lastweek, thismonth, lastmonth)
- 날짜 범위 직접 지정 지원 (26-01-01 26-01-15 형식)
- 상세 세션 목록 출력 (날짜, 시간, 소요시간)
- ephemeral 응답 (본인에게만 표시)

## 🧪 테스트
- [x] 로컬에서 테스트
- [x] 개인 워크스페이스에서 테스트

## 📸 스크린샷
지난 주 기록 14개 세션, 21시간 59분 확인됨 ✅

## ✅ 체크리스트
- [x] 코드가 정상 동작함
- [x] 기존 기능에 영향 없음
- [x] 슬랙 앱에 `/export` 커맨드 추가함