### PR TITLE
[feat/#5] export graph - 그래프 이미지 + 커맨드 구조 개선

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -1,75 +1,106 @@
 /**
  * /export 커맨드 핸들러
- * 개인 집중 기록 내보내기
+ * 개인 집중 기록 내보내기 (text, graph)
  */
 
 import type { Session } from '../types';
 import { replyEphemeral } from '../utils/slack';
-import { formatDuration, formatTime } from '../utils/format';
+import { formatDuration } from '../utils/format';
 import { getDateRange } from '../utils/date';
+
+/** 지원하는 형식 */
+const FORMATS = ['text', 'graph', 'csv'] as const;
+type ExportFormat = (typeof FORMATS)[number];
+
+/** 지원하는 기간 키워드 */
+const PERIODS = ['thisweek', 'lastweek', 'thismonth', 'lastmonth'] as const;
 
 /** /export 핸들러 */
 export async function handleExport(env: Env, teamId: string, userId: string, text: string): Promise<Response> {
-	// 인자 파싱
 	const args = text.split(' ').filter((a) => a.trim());
 
-	// 인자 없으면 이번 주 기본
+	// 기본값
+	let format: ExportFormat = 'text';
+	let periodArgs: string[] = [];
+
+	// 첫 번째 인자가 형식인지 확인
+	if (args.length > 0 && FORMATS.includes(args[0].toLowerCase() as ExportFormat)) {
+		format = args[0].toLowerCase() as ExportFormat;
+		periodArgs = args.slice(1);
+	} else {
+		periodArgs = args;
+	}
+
+	// CSV는 아직 미지원
+	if (format === 'csv') {
+		return replyEphemeral(':fairy-wand: CSV 형식은 곧 지원될 예정이에요!');
+	}
+
+	// 기간 파싱
+	const { startDate, endDate, label } = parsePeriod(periodArgs);
+
+	if (!startDate || !endDate) {
+		return replyEphemeral(getUsageMessage());
+	}
+
+	// 세션 데이터 수집
+	const sessions = await collectSessions(env, teamId, userId, startDate, endDate);
+
+	// 세션이 없으면
+	if (sessions.length === 0) {
+		return replyEphemeral(`:fairy-chart: *${label}* 기간에 기록이 없어요!\n\n요정이 기다리고 있을게요 :fairy-wand:`);
+	}
+
+	// 형식에 따라 출력
+	switch (format) {
+		case 'text':
+			return generateTextExport(sessions, label);
+		case 'graph':
+			return generateGraphExport(sessions, label, startDate, endDate);
+		default:
+			return replyEphemeral(getUsageMessage());
+	}
+}
+
+/** 기간 인자 파싱 */
+function parsePeriod(args: string[]): { startDate: string; endDate: string; label: string } {
+	// 인자 없으면 이번 주
 	if (args.length === 0) {
-		const { startDate, endDate, label } = getDateRange('thisweek');
-		return generateExportText(env, teamId, userId, startDate, endDate, label);
+		return getDateRange('thisweek');
 	}
 
 	// 단일 인자: 기간 키워드
 	if (args.length === 1) {
 		const period = args[0].toLowerCase();
-		if (['thisweek', 'lastweek', 'thismonth', 'lastmonth'].includes(period)) {
-			const { startDate, endDate, label } = getDateRange(period);
-			return generateExportText(env, teamId, userId, startDate, endDate, label);
+		if (PERIODS.includes(period as (typeof PERIODS)[number])) {
+			return getDateRange(period);
 		}
-		return replyEphemeral(getUsageMessage());
+		return { startDate: '', endDate: '', label: '' };
 	}
 
-	// 두 인자: 날짜 범위
+	// 두 인자: 날짜 범위 (YY-MM-DD YY-MM-DD)
 	if (args.length === 2) {
-		const startInput = args[0];
-		const endInput = args[1];
-
-		// YY-MM-DD 형식 체크
-		if (!/^\d{2}-\d{2}-\d{2}$/.test(startInput) || !/^\d{2}-\d{2}-\d{2}$/.test(endInput)) {
-			return replyEphemeral(getUsageMessage());
+		const [startInput, endInput] = args;
+		if (/^\d{2}-\d{2}-\d{2}$/.test(startInput) && /^\d{2}-\d{2}-\d{2}$/.test(endInput)) {
+			return {
+				startDate: '20' + startInput,
+				endDate: '20' + endInput,
+				label: `${startInput} ~ ${endInput}`,
+			};
 		}
-
-		const startDate = '20' + startInput;
-		const endDate = '20' + endInput;
-		const label = `${startInput} ~ ${endInput}`;
-		return generateExportText(env, teamId, userId, startDate, endDate, label);
 	}
 
-	return replyEphemeral(getUsageMessage());
+	return { startDate: '', endDate: '', label: '' };
 }
 
-/** 사용법 메시지 */
-function getUsageMessage(): string {
-	return (
-		`:fairy-chart: */export 사용법*\n\n` +
-		`• \`/export\` - 이번 주 (기본)\n` +
-		`• \`/export thisweek\` - 이번 주\n` +
-		`• \`/export lastweek\` - 지난 주\n` +
-		`• \`/export thismonth\` - 이번 달\n` +
-		`• \`/export 26-01-01 26-01-15\` - 특정 기간`
-	);
-}
-
-/** 텍스트 형식으로 기록 출력 */
-async function generateExportText(
+/** 세션 데이터 수집 */
+async function collectSessions(
 	env: Env,
 	teamId: string,
 	userId: string,
 	startDate: string,
-	endDate: string,
-	label: string
-): Promise<Response> {
-	// 해당 기간의 세션 수집
+	endDate: string
+): Promise<Array<Session & { date: string }>> {
 	const sessions: Array<Session & { date: string }> = [];
 
 	let current = new Date(startDate + 'T00:00:00Z');
@@ -79,7 +110,6 @@ async function generateExportText(
 		const dateKey = current.toISOString().split('T')[0];
 		const daySessions: Session[] = JSON.parse((await env.STUDY_KV.get(`${teamId}:sessions:${dateKey}`)) || '[]');
 
-		// 본인 세션만 필터링
 		const mySessions = daySessions.filter((s) => s.userId === userId);
 		for (const session of mySessions) {
 			sessions.push({ ...session, date: dateKey });
@@ -88,16 +118,37 @@ async function generateExportText(
 		current.setUTCDate(current.getUTCDate() + 1);
 	}
 
-	// 세션이 없으면
-	if (sessions.length === 0) {
-		return replyEphemeral(`:fairy-chart: *${label}* 기간에 기록이 없어요!\n\n요정이 기다리고 있을게요 :fairy-wand:`);
-	}
-
 	// 시간순 정렬
 	sessions.sort((a, b) => a.start - b.start);
 
-	// 날짜별로 그룹핑
+	return sessions;
+}
+
+/** 사용법 메시지 */
+function getUsageMessage(): string {
+	return (
+		`:fairy-chart: */export 사용법*\n\n` +
+		`*형식*\n` +
+		`• \`text\` - 텍스트 목록 (기본)\n` +
+		`• \`graph\` - 그래프 이미지\n\n` +
+		`*기간*\n` +
+		`• \`thisweek\` - 이번 주 (기본)\n` +
+		`• \`lastweek\` - 지난 주\n` +
+		`• \`thismonth\` - 이번 달\n` +
+		`• \`26-01-01 26-01-15\` - 특정 기간\n\n` +
+		`*예시*\n` +
+		`• \`/export\` - 이번 주 텍스트\n` +
+		`• \`/export graph\` - 이번 주 그래프\n` +
+		`• \`/export text lastweek\` - 지난 주 텍스트\n` +
+		`• \`/export graph 26-01-01 26-01-15\` - 특정 기간 그래프`
+	);
+}
+
+/** 텍스트 형식 출력 */
+function generateTextExport(sessions: Array<Session & { date: string }>, label: string): Response {
+	const dayNames = ['일', '월', '화', '수', '목', '금', '토'];
 	const byDate: Record<string, Array<Session & { date: string }>> = {};
+
 	for (const session of sessions) {
 		if (!byDate[session.date]) {
 			byDate[session.date] = [];
@@ -105,10 +156,7 @@ async function generateExportText(
 		byDate[session.date].push(session);
 	}
 
-	// 텍스트 생성
 	const lines: string[] = [];
-	const dayNames = ['일', '월', '화', '수', '목', '금', '토'];
-
 	for (const [date, daySessions] of Object.entries(byDate)) {
 		const d = new Date(date + 'T00:00:00Z');
 		const dayName = dayNames[d.getUTCDay()];
@@ -122,7 +170,6 @@ async function generateExportText(
 		}
 	}
 
-	// 총계
 	const totalDuration = sessions.reduce((sum, s) => sum + s.duration, 0);
 
 	const message =
@@ -133,6 +180,113 @@ async function generateExportText(
 	return replyEphemeral(message);
 }
 
+/** 그래프 형식 출력 (QuickChart.io) */
+function generateGraphExport(
+	sessions: Array<Session & { date: string }>,
+	label: string,
+	startDate: string,
+	endDate: string
+): Response {
+	const dayNames = ['일', '월', '화', '수', '목', '금', '토'];
+
+	// 날짜별 집계 (시간 단위)
+	const dailyHours: Record<string, number> = {};
+
+	// 기간 내 모든 날짜 초기화
+	let current = new Date(startDate + 'T00:00:00Z');
+	const end = new Date(endDate + 'T00:00:00Z');
+
+	while (current <= end) {
+		const dateKey = current.toISOString().split('T')[0];
+		dailyHours[dateKey] = 0;
+		current.setUTCDate(current.getUTCDate() + 1);
+	}
+
+	// 세션 집계
+	for (const session of sessions) {
+		const hours = session.duration / (1000 * 60 * 60);
+		dailyHours[session.date] = (dailyHours[session.date] || 0) + hours;
+	}
+
+	// 차트 데이터 준비
+	const sortedDates = Object.keys(dailyHours).sort();
+	const labels = sortedDates.map((date) => {
+		const d = new Date(date + 'T00:00:00Z');
+		return `${d.getUTCMonth() + 1}/${d.getUTCDate()}(${dayNames[d.getUTCDay()]})`;
+	});
+	const data = sortedDates.map((date) => Math.round(dailyHours[date] * 10) / 10);
+
+	// QuickChart URL 생성
+	const chartConfig = {
+		type: 'bar',
+		data: {
+			labels: labels,
+			datasets: [
+				{
+					label: '집중 시간 (h)',
+					data: data,
+					backgroundColor: 'rgba(147, 112, 219, 0.7)',
+					borderColor: 'rgba(147, 112, 219, 1)',
+					borderWidth: 1,
+				},
+			],
+		},
+		options: {
+			scales: {
+				y: {
+					beginAtZero: true,
+					title: { display: true, text: '시간 (h)' },
+				},
+			},
+			plugins: {
+				title: {
+					display: true,
+					text: `${label} 집중 기록`,
+				},
+			},
+		},
+	};
+
+	const chartUrl = `https://quickchart.io/chart?c=${encodeURIComponent(JSON.stringify(chartConfig))}&w=600&h=300`;
+
+	// 총계 계산
+	const totalDuration = sessions.reduce((sum, s) => sum + s.duration, 0);
+	const totalHours = Math.round((totalDuration / (1000 * 60 * 60)) * 10) / 10;
+
+	// 슬랙 블록 형태로 응답
+	const blocks = [
+		{
+			type: 'section',
+			text: {
+				type: 'mrkdwn',
+				text: `:fairy-chart: *${label} 집중 기록*`,
+			},
+		},
+		{
+			type: 'image',
+			image_url: chartUrl,
+			alt_text: `${label} 집중 기록 그래프`,
+		},
+		{
+			type: 'context',
+			elements: [
+				{
+					type: 'mrkdwn',
+					text: `총 ${sessions.length}개 세션 | :fairy-hourglass: 합계 ${totalHours}시간`,
+				},
+			],
+		},
+	];
+
+	return new Response(
+		JSON.stringify({
+			response_type: 'ephemeral',
+			blocks: blocks,
+		}),
+		{ headers: { 'Content-Type': 'application/json' } }
+	);
+}
+
 /** 시간만 짧게 포맷 (HH:MM) */
 function formatTimeShort(ts: number): string {
 	const d = new Date(ts + 9 * 60 * 60 * 1000); // KST
@@ -140,4 +294,3 @@ function formatTimeShort(ts: number): string {
 	const m = d.getUTCMinutes().toString().padStart(2, '0');
 	return `${h}:${m}`;
 }
-


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #5

## 📝 변경 사항
- `/export` 커맨드 구조 개선: `/export [형식] [기간]`
- graph 형식 추가 (QuickChart.io 활용)
- 일별 막대 그래프로 집중 시간 시각화

## 📋 커맨드 예시
| 커맨드 | 결과 |
|--------|------|
| `/export` | 이번 주 텍스트 |
| `/export graph` | 이번 주 그래프 |
| `/export text lastweek` | 지난 주 텍스트 |
| `/export graph 26-01-01 26-01-15` | 특정 기간 그래프 |

## 🧪 테스트
- [x] text 형식 정상 동작
- [x] graph 형식 정상 동작
- [x] 개인 워크스페이스 테스트 완료

## ✅ 체크리스트
- [x] 코드가 정상 동작함
- [x] 기존 기능에 영향 없음