### PR TITLE
[FEAT/#19] 외부 워크스페이스 설치 지원 (OAuth 배포)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,19 +15,28 @@ import {
 } from './commands';
 import { reply } from './utils/slack';
 import { handleLanding } from './pages/landing/index';
+import { handleOAuthInstall, handleOAuthCallback } from './oauth';
 
 export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
-		// GET 요청: 집중의 나무 랜딩 페이지
+		const url = new URL(request.url);
+
+		// GET 요청 라우팅
 		if (request.method !== 'POST') {
-			const url = new URL(request.url);
-			const teamId = url.searchParams.get('team') || env.DEFAULT_TEAM_ID;
-			const weekParam = url.searchParams.get('week');
-			return handleLanding(env, teamId, weekParam);
+			switch (url.pathname) {
+				case '/slack/oauth/install':
+					return handleOAuthInstall(env);
+				case '/slack/oauth/callback':
+					return handleOAuthCallback(request, env);
+				default: {
+					const teamId = url.searchParams.get('team') || env.DEFAULT_TEAM_ID;
+					const weekParam = url.searchParams.get('week');
+					return handleLanding(env, teamId, weekParam);
+				}
+			}
 		}
 
 		// 슬랙 커맨드 엔드포인트만 허용
-		const url = new URL(request.url);
 		if (url.pathname !== '/slack/commands') {
 			return new Response('Not found', { status: 404 });
 		}

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -1,0 +1,189 @@
+/**
+ * Slack OAuth 설치 플로우 핸들러
+ * 외부 워크스페이스에서 집중요정을 설치할 수 있도록 지원
+ */
+
+const BOT_SCOPES = ['commands', 'chat:write', 'users:read', 'files:write', 'im:write'].join(',');
+
+/**
+ * "Add to Slack" 설치 페이지
+ */
+export function handleOAuthInstall(env: Env): Response {
+	const clientId = env.SLACK_CLIENT_ID;
+	if (!clientId) {
+		return new Response('OAuth is not configured', { status: 500 });
+	}
+
+	const slackAuthUrl = `https://slack.com/oauth/v2/authorize?client_id=${clientId}&scope=${BOT_SCOPES}`;
+
+	const html = `<!DOCTYPE html>
+<html lang="ko">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>집중요정 설치 | Focus Fairy</title>
+	<style>
+		* { margin: 0; padding: 0; box-sizing: border-box; }
+		body {
+			min-height: 100vh;
+			background: linear-gradient(180deg, #0a0a1a 0%, #1a1a3a 50%, #0d1f0d 100%);
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			justify-content: center;
+			font-family: 'Segoe UI', system-ui, sans-serif;
+			color: rgba(255, 255, 255, 0.85);
+		}
+		.card {
+			background: rgba(255, 255, 255, 0.05);
+			border: 1px solid rgba(167, 139, 250, 0.2);
+			border-radius: 16px;
+			padding: 3rem;
+			max-width: 420px;
+			text-align: center;
+		}
+		h1 { font-size: 1.8rem; margin-bottom: 0.5rem; }
+		.emoji { font-size: 3rem; margin-bottom: 1rem; }
+		p { color: rgba(255, 255, 255, 0.6); margin-bottom: 2rem; line-height: 1.6; }
+		.btn {
+			display: inline-block;
+			background: #a78bfa;
+			color: white;
+			padding: 14px 32px;
+			border-radius: 10px;
+			text-decoration: none;
+			font-size: 1.1rem;
+			font-weight: 600;
+			transition: all 0.3s ease;
+		}
+		.btn:hover {
+			background: #8b6ff0;
+			transform: translateY(-2px);
+			box-shadow: 0 4px 20px rgba(167, 139, 250, 0.4);
+		}
+		.scopes {
+			margin-top: 2rem;
+			font-size: 0.75rem;
+			color: rgba(255, 255, 255, 0.35);
+		}
+	</style>
+</head>
+<body>
+	<div class="card">
+		<div class="emoji">🧚‍♀️</div>
+		<h1>집중요정 설치</h1>
+		<p>슬랙 워크스페이스에 집중요정을 추가하고<br>팀의 집중 시간을 함께 기록해보세요!</p>
+		<a href="${slackAuthUrl}" class="btn">Add to Slack</a>
+		<div class="scopes">요청 권한: 슬래시 커맨드, 메시지 전송, 사용자 조회, 파일 전송</div>
+	</div>
+</body>
+</html>`;
+
+	return new Response(html, {
+		headers: { 'Content-Type': 'text/html; charset=utf-8' },
+	});
+}
+
+/**
+ * OAuth 콜백 핸들러 — 인증 코드를 봇 토큰으로 교환 후 KV에 저장
+ */
+export async function handleOAuthCallback(request: Request, env: Env): Promise<Response> {
+	const url = new URL(request.url);
+	const code = url.searchParams.get('code');
+	const error = url.searchParams.get('error');
+
+	if (error) {
+		return renderResult(false, '설치가 취소되었어요.');
+	}
+
+	if (!code) {
+		return renderResult(false, '인증 코드가 없어요.');
+	}
+
+	try {
+		const response = await fetch('https://slack.com/api/oauth.v2.access', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: new URLSearchParams({
+				client_id: env.SLACK_CLIENT_ID,
+				client_secret: env.SLACK_CLIENT_SECRET,
+				code,
+			}),
+		});
+
+		const data = (await response.json()) as OAuthResponse;
+
+		if (!data.ok || !data.access_token || !data.team?.id) {
+			console.error('OAuth exchange failed:', data.error);
+			return renderResult(false, `설치에 실패했어요: ${data.error || 'unknown error'}`);
+		}
+
+		await env.STUDY_KV.put(`tokens:${data.team.id}`, data.access_token);
+
+		const teamName = data.team.name || data.team.id;
+		return renderResult(true, `${teamName} 워크스페이스에 집중요정이 설치되었어요!`);
+	} catch (err) {
+		console.error('OAuth callback error:', err);
+		return renderResult(false, '서버 오류가 발생했어요.');
+	}
+}
+
+interface OAuthResponse {
+	ok: boolean;
+	access_token?: string;
+	token_type?: string;
+	scope?: string;
+	bot_user_id?: string;
+	app_id?: string;
+	team?: { name?: string; id: string };
+	error?: string;
+}
+
+function renderResult(success: boolean, message: string): Response {
+	const emoji = success ? '🎉' : '😢';
+	const color = success ? '#34D399' : '#F87171';
+
+	const html = `<!DOCTYPE html>
+<html lang="ko">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>${success ? '설치 완료' : '설치 실패'} | Focus Fairy</title>
+	<style>
+		* { margin: 0; padding: 0; box-sizing: border-box; }
+		body {
+			min-height: 100vh;
+			background: linear-gradient(180deg, #0a0a1a 0%, #1a1a3a 50%, #0d1f0d 100%);
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			font-family: 'Segoe UI', system-ui, sans-serif;
+			color: rgba(255, 255, 255, 0.85);
+		}
+		.card {
+			background: rgba(255, 255, 255, 0.05);
+			border: 1px solid ${color}44;
+			border-radius: 16px;
+			padding: 3rem;
+			max-width: 420px;
+			text-align: center;
+		}
+		.emoji { font-size: 3rem; margin-bottom: 1rem; }
+		h1 { font-size: 1.5rem; margin-bottom: 1rem; color: ${color}; }
+		p { color: rgba(255, 255, 255, 0.6); line-height: 1.6; }
+	</style>
+</head>
+<body>
+	<div class="card">
+		<div class="emoji">${emoji}</div>
+		<h1>${message}</h1>
+		<p>${success ? '슬랙에서 /start 명령어로 집중을 시작해보세요! 🧚‍♀️' : '다시 시도해주세요.'}</p>
+	</div>
+</body>
+</html>`;
+
+	return new Response(html, {
+		status: success ? 200 : 400,
+		headers: { 'Content-Type': 'text/html; charset=utf-8' },
+	});
+}

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -16,10 +16,14 @@ export function replyEphemeral(text: string): Response {
 	});
 }
 
-/** Team ID에 맞는 Bot Token 가져오기 */
-export function getBotToken(env: Env, teamId: string): string | null {
+/** Team ID에 맞는 Bot Token 가져오기 (KV 우선, 시크릿 폴백) */
+export async function getBotToken(env: Env, teamId: string): Promise<string | null> {
+	// 1. KV에서 조회 (OAuth 설치된 토큰)
+	const kvToken = await env.STUDY_KV.get(`tokens:${teamId}`);
+	if (kvToken) return kvToken;
+
+	// 2. 시크릿 폴백 (기존 수동 등록 토큰)
 	try {
-		// JSON 형식: {"T123":"xoxb-...", "T456":"xoxb-..."}
 		if (env.SLACK_BOT_TOKENS) {
 			const tokens = JSON.parse(env.SLACK_BOT_TOKENS) as Record<string, string>;
 			return tokens[teamId] || null;
@@ -33,7 +37,7 @@ export function getBotToken(env: Env, teamId: string): string | null {
 
 /** 채널에 메시지 전송 (chat.postMessage API) */
 export async function postMessage(env: Env, teamId: string, channel: string, text: string): Promise<boolean> {
-	const token = getBotToken(env, teamId);
+	const token = await getBotToken(env, teamId);
 	if (!token) {
 		console.error('No bot token for team:', teamId);
 		return false;
@@ -72,7 +76,7 @@ export async function getUserName(env: Env, teamId: string, userId: string): Pro
 		return userNameCache.get(cacheKey)!;
 	}
 
-	const token = getBotToken(env, teamId);
+	const token = await getBotToken(env, teamId);
 	if (!token) {
 		return userId;
 	}
@@ -159,7 +163,7 @@ export async function uploadFile(
 	filename: string,
 	title: string
 ): Promise<boolean> {
-	const token = getBotToken(env, teamId);
+	const token = await getBotToken(env, teamId);
 	if (!token) {
 		console.error('No bot token for team:', teamId);
 		return false;

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -8,6 +8,8 @@ declare namespace Cloudflare {
 	interface Env {
 		STUDY_KV: KVNamespace;
 		SLACK_BOT_TOKENS: string;
+		SLACK_CLIENT_ID: string;
+		SLACK_CLIENT_SECRET: string;
 		DEFAULT_TEAM_ID: string;
 	}
 }


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #19

## 📝 변경 사항

### OAuth 설치 플로우 추가
- `/slack/oauth/install` — "Add to Slack" 설치 페이지 (Focus Tree 테마)
- `/slack/oauth/callback` — 인증 코드 → 봇 토큰 교환 후 KV 자동 저장
- 설치 성공/실패 결과 페이지

### 봇 토큰 조회 방식 변경
- `getBotToken()` — KV 우선 조회, 기존 `SLACK_BOT_TOKENS` 시크릿 폴백 유지
- 기존 워크스페이스는 변경 없이 그대로 동작

### 환경변수 추가
- `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET` 시크릿 등록 완료

### 변경 파일
- **신규** `src/oauth.ts` — OAuth 핸들러
- `src/index.ts` — OAuth 라우트 추가
- `src/utils/slack.ts` — `getBotToken()` async 전환 + KV 조회
- `worker-configuration.d.ts` — 환경변수 타입 추가

## 🧪 테스트

- [x] 로컬에서 `npm run dev`로 테스트
- [ ] 개인 워크스페이스에서 테스트 (새 워크스페이스에서 Install URL로 설치)
- [ ] 기존 워크스페이스 커맨드 정상 동작 확인

## 📸 스크린샷

설치 페이지 (`/slack/oauth/install`):
🧚‍♀️
집중요정 설치
슬랙 워크스페이스에 집중요정을 추가하고
팀의 집중 시간을 함께 기록해보세요!
[ Add to Slack ]

설치 완료 시:
🎉
{워크스페이스명} 워크스페이스에 집중요정이 설치되었어요!
슬랙에서 /start 명령어로 집중을 시작해보세요! 🧚‍♀️


## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 기존 기능에 영향 없음
- [x] (해당 시) 새로운 환경변수/시크릿 추가함 → `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`