### PR TITLE
[FEAT/#32] /start plan 모달로 계획 입력

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -2,11 +2,24 @@
  * /start 커맨드 핸들러
  */
 
-import { reply, replyEphemeral, postMessage, getUserName } from '../utils/slack';
+import { reply, replyEphemeral, postMessage, getUserName, getBotToken } from '../utils/slack';
 import { formatTime, formatDuration } from '../utils/format';
 import { getTodayKey } from '../utils/date';
 
-export async function handleStart(env: Env, teamId: string, userId: string, channelId: string, text: string): Promise<Response> {
+const RESERVED_SUBCOMMANDS = ['plan'];
+
+export async function handleStart(
+	env: Env,
+	teamId: string,
+	userId: string,
+	channelId: string,
+	text: string,
+	triggerId?: string
+): Promise<Response> {
+	if (text === 'plan') {
+		return handleStartPlan(env, teamId, userId, channelId, triggerId);
+	}
+
 	const now = Date.now();
 	const existing = await env.STUDY_KV.get(`${teamId}:checkin:${userId}`);
 
@@ -22,7 +35,8 @@ export async function handleStart(env: Env, teamId: string, userId: string, chan
 		return replyEphemeral(`이미 집중 중이에요! 요정이 지켜보고 있어요 :fairy-hourglass: (${elapsed} 경과)`);
 	}
 
-	const checkinData = text ? JSON.stringify({ time: now, label: text }) : now.toString();
+	const label = text && !RESERVED_SUBCOMMANDS.includes(text) ? text : '';
+	const checkinData = label ? JSON.stringify({ time: now, label }) : now.toString();
 	await env.STUDY_KV.put(`${teamId}:checkin:${userId}`, checkinData);
 
 	const todayKey = getTodayKey();
@@ -35,8 +49,8 @@ export async function handleStart(env: Env, teamId: string, userId: string, chan
 	const userName = await getUserName(env, teamId, userId);
 
 	let publicMessage = `:fairy-wand: <@${userId}>님이 집중을 시작했어요! 화이팅! (${formatTime(now)})`;
-	if (text) {
-		publicMessage += `\n:fairy-sprout: 계획: ${text}`;
+	if (label) {
+		publicMessage += `\n:fairy-sprout: 계획: ${label}`;
 	}
 
 	const posted = await postMessage(env, teamId, channelId, publicMessage);
@@ -46,4 +60,79 @@ export async function handleStart(env: Env, teamId: string, userId: string, chan
 	} else {
 		return reply(publicMessage);
 	}
+}
+
+async function handleStartPlan(
+	env: Env,
+	teamId: string,
+	userId: string,
+	channelId: string,
+	triggerId?: string
+): Promise<Response> {
+	if (!triggerId) {
+		return replyEphemeral('모달을 열 수 없어요. 다시 시도해주세요!');
+	}
+
+	const existing = await env.STUDY_KV.get(`${teamId}:checkin:${userId}`);
+	if (existing) {
+		let startTime: number;
+		try {
+			const parsed = JSON.parse(existing);
+			startTime = typeof parsed === 'object' && parsed.time ? parsed.time : parseInt(existing);
+		} catch {
+			startTime = parseInt(existing);
+		}
+		const elapsed = formatDuration(Date.now() - startTime);
+		return replyEphemeral(`이미 집중 중이에요! 요정이 지켜보고 있어요 :fairy-hourglass: (${elapsed} 경과)`);
+	}
+
+	const token = await getBotToken(env, teamId);
+	if (!token) {
+		return replyEphemeral('봇 토큰을 찾을 수 없어요.');
+	}
+
+	const modal = {
+		trigger_id: triggerId,
+		view: {
+			type: 'modal',
+			callback_id: 'start_plan_modal',
+			private_metadata: channelId,
+			title: { type: 'plain_text', text: '집중 시작' },
+			submit: { type: 'plain_text', text: '시작!' },
+			close: { type: 'plain_text', text: '취소' },
+			blocks: [
+				{
+					type: 'input',
+					block_id: 'plan_block',
+					label: { type: 'plain_text', text: ':fairy-sprout: 오늘의 계획' },
+					element: {
+						type: 'plain_text_input',
+						action_id: 'plan_input',
+						multiline: true,
+						placeholder: {
+							type: 'plain_text',
+							text: '기획서 작성\n코드리뷰\nPR 머지',
+						},
+					},
+				},
+			],
+		},
+	};
+
+	const res = await fetch('https://slack.com/api/views.open', {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${token}`,
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify(modal),
+	});
+
+	const data = (await res.json()) as { ok: boolean; error?: string };
+	if (!data.ok) {
+		console.error('Failed to open modal:', data.error);
+		return replyEphemeral('모달을 열 수 없어요. 다시 시도해주세요!');
+	}
+
+	return new Response('', { status: 200 });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
 import { reply } from './utils/slack';
 import { handleLanding } from './pages/landing/index';
 import { handleOAuthInstall, handleOAuthCallback } from './pages/install/index';
+import { handleInteraction } from './interactions';
 
 export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
@@ -36,23 +37,26 @@ export default {
 			}
 		}
 
-		// 슬랙 커맨드 엔드포인트만 허용
+		// Slack Interactivity 엔드포인트
+		if (url.pathname === '/slack/interactions') {
+			return handleInteraction(request, env);
+		}
+
 		if (url.pathname !== '/slack/commands') {
 			return new Response('Not found', { status: 404 });
 		}
 
-		// 폼 데이터 파싱
 		const formData = await request.formData();
 		const command = formData.get('command') as string;
 		const userId = formData.get('user_id') as string;
 		const teamId = formData.get('team_id') as string;
 		const channelId = formData.get('channel_id') as string;
 		const text = (formData.get('text') as string)?.trim() || '';
+		const triggerId = (formData.get('trigger_id') as string) || '';
 
-		// 커맨드 라우팅
 		switch (command) {
 			case '/start':
-				return handleStart(env, teamId, userId, channelId, text);
+				return handleStart(env, teamId, userId, channelId, text, triggerId);
 			case '/end':
 				return handleEnd(env, teamId, userId, channelId, text);
 			case '/weekly':

--- a/src/interactions/index.ts
+++ b/src/interactions/index.ts
@@ -1,0 +1,97 @@
+/**
+ * Slack Interactivity 핸들러
+ * 모달 제출, 버튼 클릭 등 interactive component 이벤트 처리
+ */
+
+import { postMessage, replyEphemeral } from '../utils/slack';
+import { formatTime } from '../utils/format';
+import { getTodayKey } from '../utils/date';
+
+interface SlackInteractionPayload {
+	type: string;
+	user: { id: string; team_id: string };
+	view?: {
+		callback_id: string;
+		private_metadata: string;
+		state: {
+			values: Record<string, Record<string, { value: string }>>;
+		};
+	};
+}
+
+export async function handleInteraction(request: Request, env: Env): Promise<Response> {
+	const formData = await request.formData();
+	const payloadStr = formData.get('payload') as string;
+
+	if (!payloadStr) {
+		return new Response('', { status: 200 });
+	}
+
+	const payload: SlackInteractionPayload = JSON.parse(payloadStr);
+
+	switch (payload.type) {
+		case 'view_submission':
+			return handleViewSubmission(payload, env);
+		default:
+			return new Response('', { status: 200 });
+	}
+}
+
+async function handleViewSubmission(payload: SlackInteractionPayload, env: Env): Promise<Response> {
+	const { view, user } = payload;
+	if (!view) return new Response('', { status: 200 });
+
+	switch (view.callback_id) {
+		case 'start_plan_modal':
+			return handleStartPlanSubmission(user.id, user.team_id, view, env);
+		default:
+			return new Response('', { status: 200 });
+	}
+}
+
+async function handleStartPlanSubmission(
+	userId: string,
+	teamId: string,
+	view: NonNullable<SlackInteractionPayload['view']>,
+	env: Env
+): Promise<Response> {
+	const planText = view.state.values['plan_block']?.['plan_input']?.value?.trim();
+	const channelId = view.private_metadata;
+
+	if (!planText || !channelId) {
+		return new Response('', { status: 200 });
+	}
+
+	const now = Date.now();
+	const existing = await env.STUDY_KV.get(`${teamId}:checkin:${userId}`);
+
+	if (existing) {
+		return new Response(JSON.stringify({
+			response_action: 'errors',
+			errors: { plan_block: '이미 집중 중이에요! /end로 먼저 종료해주세요.' },
+		}), { headers: { 'Content-Type': 'application/json' } });
+	}
+
+	const checkinData = JSON.stringify({ time: now, label: planText });
+	await env.STUDY_KV.put(`${teamId}:checkin:${userId}`, checkinData);
+
+	const todayKey = getTodayKey();
+	const todayList: string[] = JSON.parse((await env.STUDY_KV.get(`${teamId}:today:${todayKey}`)) || '[]');
+	if (!todayList.includes(userId)) {
+		todayList.push(userId);
+		await env.STUDY_KV.put(`${teamId}:today:${todayKey}`, JSON.stringify(todayList));
+	}
+
+	const lines = planText.split('\n').filter((l: string) => l.trim());
+	const planDisplay = lines.length > 1
+		? '\n' + lines.map((l: string) => `• ${l.trim()}`).join('\n')
+		: ` ${planText}`;
+
+	const publicMessage =
+		`:fairy-wand: <@${userId}>님이 집중을 시작했어요! 화이팅! (${formatTime(now)})` +
+		`\n:fairy-sprout: 계획:${planDisplay}`;
+
+	await postMessage(env, teamId, channelId, publicMessage);
+
+	return new Response('', { status: 200 });
+}


### PR DESCRIPTION
## Summary
- `/start plan` 입력 시 모달 팝업으로 여러 줄 계획 입력 가능
- 모달 제출 시 채널에 체크리스트 형태로 계획 표시 (여러 줄이면 bullet point)
- `/slack/interactions` 엔드포인트 신규 추가 (Slack Interactivity 기반)
- 기존 `/start`, `/start 텍스트` 동작은 그대로 유지

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `src/index.ts` | `/slack/interactions` 라우트 추가, `trigger_id` 전달 |
| `src/commands/start.ts` | `plan` 서브커맨드 분기, `views.open`으로 모달 오픈 |
| `src/interactions/index.ts` | 신규 - `view_submission` 핸들러 (모달 제출 처리) |

## Test plan
- [x] `/start plan` → 모달 팝업 정상 표시
- [x] 모달에서 여러 줄 입력 후 제출 → 채널에 bullet point 형태로 표시
- [x] 모달에서 한 줄 입력 → 인라인으로 표시
- [x] 이미 집중 중일 때 모달 제출 → 모달 내 에러 메시지 표시
- [x] 기존 `/start`, `/start 텍스트` 동작 영향 없음 확인
- [x] OAuth 설치 워크스페이스에서 정상 동작 확인
- [x] Cloudflare Workers 배포 후 실제 Slack에서 동작 확인 완료

Closes #32