### PR TITLE
[FEAT/#27] /cheer 팀원 응원 커맨드

### DIFF
--- a/src/commands/cheer.ts
+++ b/src/commands/cheer.ts
@@ -1,0 +1,177 @@
+/**
+ * /cheer 커맨드 핸들러
+ * 팀원에게 :fairy-coffee: 응원 보내기
+ */
+
+import { replyEphemeral, postMessage, lookupUserByName } from '../utils/slack';
+import { getTodayKey, getWeekRangeForDate } from '../utils/date';
+import { DAILY_CHEER_LIMIT, MEDALS } from '../constants/messages';
+
+interface CheerLog {
+	from: string;
+	to: string;
+	message?: string;
+	time: number;
+}
+
+export async function handleCheer(
+	env: Env,
+	teamId: string,
+	userId: string,
+	channelId: string,
+	text: string
+): Promise<Response> {
+	if (!text) {
+		return replyEphemeral(
+			':fairy-coffee: 사용법:\n' +
+			'• `/cheer @팀원` — 커피 1잔 보내기\n' +
+			'• `/cheer @팀원 화이팅!` — 메시지와 함께 응원\n' +
+			'• `/cheer @팀원 :fairy-coffee::fairy-coffee::fairy-coffee:` — 커피 여러 잔 보내기\n' +
+			'• `/cheer leaderboard` — 이번 주 응원 랭킹 (보낸 커피)\n' +
+			'• `/cheer leaderboard received` — 받은 커피 랭킹\n' +
+			`• 하루 ${DAILY_CHEER_LIMIT}잔 제한`
+		);
+	}
+
+	if (text === 'leaderboard' || text === 'leaderboard received') {
+		return showLeaderboard(env, teamId, text === 'leaderboard received' ? 'received' : 'given');
+	}
+
+	return sendCheer(env, teamId, userId, channelId, text);
+}
+
+async function sendCheer(
+	env: Env,
+	teamId: string,
+	userId: string,
+	channelId: string,
+	text: string
+): Promise<Response> {
+	let targetUserId: string | null = null;
+	let cheerMessage = '';
+
+	const escapedMatch = text.match(/<@([A-Z0-9]+)(?:\|[^>]*)?>/);
+	if (escapedMatch) {
+		targetUserId = escapedMatch[1];
+		cheerMessage = text.replace(escapedMatch[0], '').trim();
+	} else {
+		const plainMatch = text.match(/@(\S+)/);
+		if (plainMatch) {
+			targetUserId = await lookupUserByName(env, teamId, plainMatch[1]);
+			cheerMessage = text.replace(plainMatch[0], '').trim();
+		}
+	}
+
+	if (!targetUserId) {
+		return replyEphemeral(':fairy-wand: 응원할 팀원을 멘션해주세요! 예: `/cheer @팀원 화이팅!`');
+	}
+
+	if (targetUserId === userId) {
+		return replyEphemeral(':fairy-zzz: 자기 자신에게는 응원을 보낼 수 없어요!');
+	}
+
+	const coffeeMatches = cheerMessage.match(/:fairy-coffee:/g);
+	const coffeeCount = coffeeMatches ? coffeeMatches.length : 1;
+	const displayMessage = cheerMessage.replace(/:fairy-coffee:/g, '').trim();
+
+	const todayKey = getTodayKey();
+	const sentKey = `${teamId}:cheer:sent:${userId}:${todayKey}`;
+	const sentCount = parseInt((await env.STUDY_KV.get(sentKey)) || '0');
+
+	if (sentCount >= DAILY_CHEER_LIMIT) {
+		return replyEphemeral(
+			`:fairy-zzz: 오늘의 커피를 모두 사용했어요! 내일 다시 충전돼요 (${DAILY_CHEER_LIMIT}/${DAILY_CHEER_LIMIT})`
+		);
+	}
+
+	const actualCount = Math.min(coffeeCount, DAILY_CHEER_LIMIT - sentCount);
+	await env.STUDY_KV.put(sentKey, (sentCount + actualCount).toString(), { expirationTtl: 86400 * 2 });
+
+	const logKey = `${teamId}:cheer:log:${todayKey}`;
+	const logs: CheerLog[] = JSON.parse((await env.STUDY_KV.get(logKey)) || '[]');
+	for (let i = 0; i < actualCount; i++) {
+		logs.push({
+			from: userId,
+			to: targetUserId,
+			...(displayMessage && { message: displayMessage }),
+			time: Date.now(),
+		});
+	}
+	await env.STUDY_KV.put(logKey, JSON.stringify(logs));
+
+	const weeklyReceived = await getWeeklyReceivedCount(env, teamId, targetUserId);
+	const remaining = DAILY_CHEER_LIMIT - (sentCount + actualCount);
+
+	const coffeeEmojis = ':fairy-coffee:'.repeat(actualCount);
+	let publicMessage =
+		`${coffeeEmojis} <@${userId}>님이 <@${targetUserId}>님에게 커피 ${actualCount}잔을 보냈어요!`;
+	if (displayMessage) {
+		publicMessage += `\n💬 "${displayMessage}"`;
+	}
+	publicMessage += `\n:fairy-sprout: 이번 주 받은 응원: ${weeklyReceived}개 | 남은 커피: ${remaining}/${DAILY_CHEER_LIMIT}`;
+
+	if (coffeeCount > actualCount) {
+		publicMessage += `\n:fairy-zzz: (${coffeeCount}잔 요청했지만 남은 커피가 ${actualCount}잔이라 ${actualCount}잔만 보냈어요)`;
+	}
+
+	const posted = await postMessage(env, teamId, channelId, publicMessage);
+
+	if (posted) {
+		return replyEphemeral(`:fairy-coffee: 커피 ${actualCount}잔을 보냈어요! 남은 커피: ${remaining}/${DAILY_CHEER_LIMIT}`);
+	} else {
+		return replyEphemeral(':fairy-zzz: 응원 전송에 실패했어요. 봇이 채널에 초대되어 있는지 확인해주세요!');
+	}
+}
+
+async function showLeaderboard(env: Env, teamId: string, mode: 'given' | 'received'): Promise<Response> {
+	const { startDate, endDate } = getWeekRangeForDate(Date.now());
+	const counts: Record<string, number> = {};
+
+	const start = new Date(startDate);
+	const end = new Date(endDate);
+	for (let d = new Date(start); d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
+		const dateKey = d.toISOString().split('T')[0];
+		const logKey = `${teamId}:cheer:log:${dateKey}`;
+		const logs: CheerLog[] = JSON.parse((await env.STUDY_KV.get(logKey)) || '[]');
+		for (const log of logs) {
+			const key = mode === 'given' ? log.from : log.to;
+			counts[key] = (counts[key] || 0) + 1;
+		}
+	}
+
+	const sorted = Object.entries(counts)
+		.sort(([, a], [, b]) => b - a);
+
+	if (sorted.length === 0) {
+		return replyEphemeral(':fairy-coffee: 이번 주는 아직 응원이 없어요! 첫 번째 응원을 보내보세요!');
+	}
+
+	const isGiven = mode === 'given';
+	const emoji = isGiven ? ':fairy-coffee:' : ':fairy-sprout:';
+	const title = isGiven ? '이번 주 커피 히어로' : '이번 주 인기스타';
+	const subtitle = isGiven ? '가장 많이 응원한 사람들' : '가장 많이 응원받은 사람들';
+	let leaderboard = `${emoji} *${title}*\n${subtitle}\n\n`;
+	for (let i = 0; i < sorted.length; i++) {
+		const [uid, count] = sorted[i];
+		const medal = i < MEDALS.length ? MEDALS[i] : `${i + 1}.`;
+		leaderboard += `${medal} <@${uid}> — ${count}잔\n`;
+	}
+
+	return replyEphemeral(leaderboard);
+}
+
+async function getWeeklyReceivedCount(env: Env, teamId: string, targetUserId: string): Promise<number> {
+	const { startDate, endDate } = getWeekRangeForDate(Date.now());
+	let count = 0;
+
+	const start = new Date(startDate);
+	const end = new Date(endDate);
+	for (let d = new Date(start); d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
+		const dateKey = d.toISOString().split('T')[0];
+		const logKey = `${teamId}:cheer:log:${dateKey}`;
+		const logs: CheerLog[] = JSON.parse((await env.STUDY_KV.get(logKey)) || '[]');
+		count += logs.filter(l => l.to === targetUserId).length;
+	}
+
+	return count;
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -9,3 +9,4 @@ export { handleToday } from './today';
 export { handleWeekly, handleReportCommand } from './report';
 export { handleExport } from './export';
 export { handlePattern } from './pattern';
+export { handleCheer } from './cheer';

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -38,3 +38,6 @@ export const SESSION_TAGS = [
 
 export const DEFAULT_TAG = 'etc';
 
+/** 하루 응원 보내기 한도 */
+export const DAILY_CHEER_LIMIT = 5;
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
 	handleReportCommand,
 	handleExport,
 	handlePattern,
+	handleCheer,
 } from './commands';
 import { reply } from './utils/slack';
 import { handleLanding } from './pages/landing/index';
@@ -71,6 +72,8 @@ export default {
 				return handleExport(env, teamId, userId, channelId, text);
 			case '/pattern':
 				return handlePattern(env, teamId, userId, text);
+			case '/cheer':
+				return handleCheer(env, teamId, userId, channelId, text);
 			default:
 				return reply('알 수 없는 명령어예요.');
 		}

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -138,6 +138,42 @@ export async function updateMessage(
 	}
 }
 
+/** @username으로 유저 ID 조회 (users.list에서 name/display_name 매칭) */
+export async function lookupUserByName(env: Env, teamId: string, username: string): Promise<string | null> {
+	const token = await getBotToken(env, teamId);
+	if (!token) return null;
+
+	try {
+		const response = await fetch('https://slack.com/api/users.list?limit=200', {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		const data = (await response.json()) as {
+			ok: boolean;
+			members?: Array<{
+				id: string;
+				name?: string;
+				profile?: { display_name?: string; display_name_normalized?: string };
+				deleted?: boolean;
+			}>;
+		};
+
+		if (!data.ok || !data.members) return null;
+
+		const lower = username.toLowerCase();
+		const found = data.members.find(
+			(m) =>
+				!m.deleted &&
+				(m.name?.toLowerCase() === lower ||
+					m.profile?.display_name?.toLowerCase() === lower ||
+					m.profile?.display_name_normalized?.toLowerCase() === lower)
+		);
+		return found?.id || null;
+	} catch (error) {
+		console.error('Failed to lookup user by name:', error);
+		return null;
+	}
+}
+
 /** 사용자 이름 캐시 (요청당 메모리 캐시) */
 const userNameCache = new Map<string, string>();
 


### PR DESCRIPTION
## Summary

HeyTaco에서 영감을 받아 팀원 간 `:fairy-coffee:` 커피 응원 기능을 추가합니다.

- `/cheer @팀원 [메시지]` — 커피 보내기 (기본 1잔, 하루 5잔 제한)
- `/cheer @팀원 :fairy-coffee::fairy-coffee::fairy-coffee:` — 이모지 개수만큼 여러 잔 전송
- `/cheer leaderboard` — 이번 주 커피 히어로 (보낸 커피 기준 랭킹)
- `/cheer leaderboard received` — 이번 주 인기스타 (받은 커피 기준 랭킹)
- 자기 자신에게 보내기 불가
- 일일 한도 초과 시 안내 메시지

## 변경 파일

- `src/commands/cheer.ts` (신규) — `/cheer` 핸들러 (sendCheer, showLeaderboard)
- `src/commands/index.ts` — handleCheer export 추가
- `src/index.ts` — `/cheer` 커맨드 라우팅 추가
- `src/constants/messages.ts` — `DAILY_CHEER_LIMIT = 5` 상수 추가
- `src/utils/slack.ts` — `lookupUserByName` 함수 추가 (@username 평문 멘션 대응)

## KV 데이터 구조

- `{teamId}:cheer:sent:{userId}:{dateKey}` → 일일 보낸 횟수 (TTL 2일)
- `{teamId}:cheer:log:{dateKey}` → `CheerLog[]` (주간 랭킹 집계용)

## Test plan

- [x] `/cheer @팀원 화이팅!` — 메시지 포함 응원 전송 확인
- [x] `/cheer @팀원 :fairy-coffee::fairy-coffee:` — 이모지 개수만큼 차감 확인
- [x] 자기 자신 멘션 시 에러 메시지 확인
- [x] 일일 한도 초과 시 안내 메시지 확인
- [x] `/cheer leaderboard` — 보낸 커피 기준 랭킹 표시 확인
- [x] `/cheer leaderboard received` — 받은 커피 기준 랭킹 표시 확인
- [x] @username 평문 멘션 지원 확인
- [ ] Slack App 설정에서 `/cheer` 슬래시 커맨드 등록 필요