### PR TITLE
[FEAT/#38] /start 기본 동작에 계획 추가 버튼 포함 + 세션 소유자 가드

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -2,12 +2,12 @@
  * /start 커맨드 핸들러
  */
 
-import { reply, replyEphemeral, postMessage, postMessageWithBlocks, getUserName, getBotToken } from '../utils/slack';
+import { reply, replyEphemeral, postMessage, postMessageWithBlocks, getBotToken } from '../utils/slack';
 import { formatTime, formatDuration } from '../utils/format';
 import { getTodayKey } from '../utils/date';
 import { SESSION_TAGS, DEFAULT_TAG } from '../constants/messages';
 
-const RESERVED_SUBCOMMANDS = ['plan', 'add'];
+const RESERVED_SUBCOMMANDS = ['plan'];
 
 export async function handleStart(
 	env: Env,
@@ -19,10 +19,6 @@ export async function handleStart(
 ): Promise<Response> {
 	if (text === 'plan') {
 		return handleStartPlan(env, teamId, userId, channelId, triggerId);
-	}
-
-	if (text === 'add') {
-		return handleStartAdd(env, teamId, userId, channelId);
 	}
 
 	const now = Date.now();
@@ -51,15 +47,38 @@ export async function handleStart(
 		await env.STUDY_KV.put(`${teamId}:today:${todayKey}`, JSON.stringify(todayList));
 	}
 
-	const userName = await getUserName(env, teamId, userId);
-
 	let publicMessage = `:fairy-wand: <@${userId}>님이 집중을 시작했어요! 화이팅! (${formatTime(now)})`;
 	if (label) {
 		publicMessage += `\n:fairy-sprout: 계획: ${label}`;
 	}
 
-	const posted = await postMessage(env, teamId, channelId, publicMessage);
+	if (label) {
+		const posted = await postMessage(env, teamId, channelId, publicMessage);
+		if (posted) {
+			return replyEphemeral(':fairy-wand: 집중 시작!');
+		} else {
+			return reply(publicMessage);
+		}
+	}
 
+	const blocks = [
+		{
+			type: 'section',
+			text: { type: 'mrkdwn', text: publicMessage },
+		},
+		{
+			type: 'actions',
+			elements: [
+				{
+					type: 'button',
+					text: { type: 'plain_text', text: ':fairy-sprout: 계획 추가' },
+					action_id: 'add_plan_button',
+				},
+			],
+		},
+	];
+
+	const posted = await postMessageWithBlocks(env, teamId, channelId, publicMessage, blocks);
 	if (posted) {
 		return replyEphemeral(':fairy-wand: 집중 시작!');
 	} else {
@@ -160,55 +179,3 @@ async function handleStartPlan(
 	return new Response('', { status: 200 });
 }
 
-async function handleStartAdd(env: Env, teamId: string, userId: string, channelId: string): Promise<Response> {
-	const now = Date.now();
-	const existing = await env.STUDY_KV.get(`${teamId}:checkin:${userId}`);
-
-	if (existing) {
-		let startTime: number;
-		try {
-			const parsed = JSON.parse(existing);
-			startTime = typeof parsed === 'object' && parsed.time ? parsed.time : parseInt(existing);
-		} catch {
-			startTime = parseInt(existing);
-		}
-		const elapsed = formatDuration(now - startTime);
-		return replyEphemeral(`이미 집중 중이에요! 요정이 지켜보고 있어요 :fairy-hourglass: (${elapsed} 경과)`);
-	}
-
-	await env.STUDY_KV.put(`${teamId}:checkin:${userId}`, now.toString());
-
-	const todayKey = getTodayKey();
-	const todayList: string[] = JSON.parse((await env.STUDY_KV.get(`${teamId}:today:${todayKey}`)) || '[]');
-	if (!todayList.includes(userId)) {
-		todayList.push(userId);
-		await env.STUDY_KV.put(`${teamId}:today:${todayKey}`, JSON.stringify(todayList));
-	}
-
-	const publicMessage = `:fairy-wand: <@${userId}>님이 집중을 시작했어요! 화이팅! (${formatTime(now)})`;
-
-	const blocks = [
-		{
-			type: 'section',
-			text: { type: 'mrkdwn', text: publicMessage },
-		},
-		{
-			type: 'actions',
-			elements: [
-				{
-					type: 'button',
-					text: { type: 'plain_text', text: ':fairy-sprout: 계획 추가' },
-					action_id: 'add_plan_button',
-				},
-			],
-		},
-	];
-
-	const posted = await postMessageWithBlocks(env, teamId, channelId, publicMessage, blocks);
-
-	if (posted) {
-		return replyEphemeral(':fairy-wand: 집중 시작!');
-	} else {
-		return reply(publicMessage);
-	}
-}

--- a/src/interactions/index.ts
+++ b/src/interactions/index.ts
@@ -3,7 +3,7 @@
  * 모달 제출, 버튼 클릭 등 interactive component 이벤트 처리
  */
 
-import { postMessage, updateMessage, getBotToken } from '../utils/slack';
+import { postMessage, updateMessage, getBotToken, postEphemeral } from '../utils/slack';
 import { formatTime } from '../utils/format';
 import { getTodayKey } from '../utils/date';
 import { SESSION_TAGS, DEFAULT_TAG } from '../constants/messages';
@@ -92,6 +92,12 @@ async function handleBlockActions(payload: SlackInteractionPayload, env: Env): P
 async function handleAddPlanButton(payload: SlackInteractionPayload, env: Env): Promise<Response> {
 	const { trigger_id, user, channel, message } = payload;
 	if (!trigger_id || !channel || !message) {
+		return new Response('', { status: 200 });
+	}
+
+	const ownerMatch = message.text?.match(/<@([A-Z0-9]+)>/);
+	if (ownerMatch && ownerMatch[1] !== user.id) {
+		await postEphemeral(env, user.team_id, channel.id, user.id, ':fairy-zzz: 본인의 세션만 수정할 수 있어요!');
 		return new Response('', { status: 200 });
 	}
 
@@ -273,6 +279,11 @@ async function handleEditPlanButton(payload: SlackInteractionPayload, env: Env):
 	const userIdMatch = headerText.match(/<@([^>]+)>/);
 	const userId = userIdMatch ? userIdMatch[1] : user.id;
 
+	if (userId !== user.id) {
+		await postEphemeral(env, user.team_id, channel.id, user.id, ':fairy-zzz: 본인의 세션만 수정할 수 있어요!');
+		return new Response('', { status: 200 });
+	}
+
 	const checkIn = await env.STUDY_KV.get(`${user.team_id}:checkin:${userId}`);
 	if (!checkIn) {
 		return new Response('', { status: 200 });
@@ -415,11 +426,17 @@ async function handleToggleCheck(payload: SlackInteractionPayload, env: Env): Pr
 	const action = actions[0];
 	const blocks = message.blocks || [];
 
-	// 헤더에서 userId와 startTime 추출
 	const headerBlock = blocks.find((b) => b.block_id === 'checklist_header');
 	const headerText = headerBlock?.text?.text || '';
 	const userIdMatch = headerText.match(/<@([^>]+)>/);
 	const userId = userIdMatch ? userIdMatch[1] : user.id;
+
+	if (userId !== user.id) {
+		if (channel) {
+			await postEphemeral(env, user.team_id, channel.id, user.id, ':fairy-zzz: 본인의 세션만 수정할 수 있어요!');
+		}
+		return new Response('', { status: 200 });
+	}
 
 	// 체크리스트 항목 수집 및 토글
 	const items: string[] = [];

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -65,6 +65,27 @@ export async function postMessage(env: Env, teamId: string, channel: string, tex
 	}
 }
 
+/** 특정 유저에게만 보이는 ephemeral 메시지 전송 */
+export async function postEphemeral(env: Env, teamId: string, channel: string, userId: string, text: string): Promise<boolean> {
+	const token = await getBotToken(env, teamId);
+	if (!token) return false;
+
+	try {
+		const response = await fetch('https://slack.com/api/chat.postEphemeral', {
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${token}`,
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({ channel, user: userId, text }),
+		});
+		const data = (await response.json()) as { ok: boolean; error?: string };
+		return data.ok;
+	} catch {
+		return false;
+	}
+}
+
 /** 채널에 블록 메시지 전송 (버튼 등 interactive 요소 포함) */
 export async function postMessageWithBlocks(
 	env: Env,


### PR DESCRIPTION
## Summary

- `/start` 기본 동작에 "계획 추가" 버튼을 포함시켜 `/start add` 없이도 바로 계획을 추가할 수 있도록 개선
- `/start add` 서브커맨드 제거하여 커맨드 구조 단순화
- 타인의 세션 버튼(계획 추가/수정, 체크리스트 토글) 클릭 시 소유자 검증 + ephemeral 경고 메시지 추가

Closes #38

## 변경 후 커맨드 구조

| 입력 | 동작 |
|------|------|
| `/start` | 시작 메시지 + "계획 추가" 버튼 |
| `/start plan` | 모달 바로 오픈 |
| `/start 텍스트` | 텍스트를 계획으로 저장 (버튼 없이) |

<img width="500" alt="image" src="https://github.com/user-attachments/assets/f2e3cd55-06c3-48ed-8985-2fa1c69d15cc" />



## 변경 파일

- `src/commands/start.ts` — `/start add` 분기 제거, `/start` 기본에 버튼 포함
- `src/interactions/index.ts` — 3곳에 세션 소유자 가드 추가 (계획 추가/수정 버튼, 체크리스트 토글)
- `src/utils/slack.ts` — `postEphemeral` 유틸 함수 추가

## Test plan

- [x] `/start` 입력 시 시작 메시지 + "계획 추가" 버튼 표시 확인
- [x] `/start plan` 모달 정상 동작 확인
- [x] `/start 텍스트` 텍스트 계획 저장 확인 (버튼 없이)
- [x] 타인의 "계획 추가" 버튼 클릭 시 경고 메시지 확인
- [x] 타인의 체크리스트 토글 클릭 시 경고 메시지 확인