### PR TITLE
[FEAT/#42] /pause, /resume 일시정지/재개 기능

### DIFF
--- a/src/commands/end.ts
+++ b/src/commands/end.ts
@@ -31,6 +31,8 @@ export async function handleEnd(
 	let tag: string | undefined;
 	let messageTs: string | undefined;
 	let msgChannelId: string | undefined;
+	let totalPauseDuration = 0;
+	let wasPaused = false;
 	try {
 		const parsed = JSON.parse(checkIn);
 		if (typeof parsed === 'object' && parsed.time) {
@@ -40,6 +42,11 @@ export async function handleEnd(
 			tag = parsed.tag;
 			messageTs = parsed.messageTs;
 			msgChannelId = parsed.channelId;
+			totalPauseDuration = parsed.totalPauseDuration || 0;
+			if (parsed.pausedAt) {
+				totalPauseDuration += now - parsed.pausedAt;
+				wasPaused = true;
+			}
 		} else {
 			startTime = parseInt(checkIn);
 		}
@@ -47,7 +54,7 @@ export async function handleEnd(
 		startTime = parseInt(checkIn);
 	}
 
-	let duration = now - startTime;
+	let duration = now - startTime - totalPauseDuration;
 
 	// 6시간 초과 + 시간 입력 없으면 경고 (본인에게만)
 	if (duration > MAX_AUTO_DURATION && !text) {
@@ -75,6 +82,7 @@ export async function handleEnd(
 	if (label) session.label = label;
 	if (checked) session.checked = checked;
 	if (tag) session.tag = tag;
+	if (totalPauseDuration > 0) session.pauseDuration = totalPauseDuration;
 	sessions.push(session);
 	await env.STUDY_KV.put(sessionsKey, JSON.stringify(sessions));
 
@@ -107,8 +115,9 @@ export async function handleEnd(
 	const tagLabel = tag ? (SESSION_TAGS.find(t => t.value === tag)?.label || '기타') : undefined;
 	let publicMessage =
 		`:fairy-party: <@${userId}>님 수고했어요! (${formatTime(now)})\n` +
-		`:fairy-hourglass: 이번 세션: ${formatDuration(duration)}\n` +
-		`:fairy-chart: ${weekLabel} 누적: ${formatDuration(weekTotal)}`;
+		`:fairy-hourglass: 이번 세션: ${formatDuration(duration)}` +
+		(totalPauseDuration > 0 ? ` (휴식 ${formatDuration(totalPauseDuration)} 제외)` : '') +
+		`\n:fairy-chart: ${weekLabel} 누적: ${formatDuration(weekTotal)}`;
 	if (tagLabel) {
 		publicMessage += `\n:fairy-fire: 카테고리: ${tagLabel}`;
 	}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -10,3 +10,4 @@ export { handleWeekly, handleReportCommand } from './report';
 export { handleExport } from './export';
 export { handlePattern } from './pattern';
 export { handleCheer } from './cheer';
+export { handlePause, handleResume } from './pause';

--- a/src/commands/pause.ts
+++ b/src/commands/pause.ts
@@ -1,0 +1,89 @@
+/**
+ * /pause, /resume 커맨드 핸들러
+ * 집중 세션 일시정지 / 재개
+ */
+
+import { reply, replyEphemeral, postMessage } from '../utils/slack';
+import { formatTime, formatDuration } from '../utils/format';
+
+export async function handlePause(
+	env: Env,
+	teamId: string,
+	userId: string,
+	channelId: string
+): Promise<Response> {
+	const checkIn = await env.STUDY_KV.get(`${teamId}:checkin:${userId}`);
+
+	if (!checkIn) {
+		return replyEphemeral('아직 시작 전이에요! /start로 요정을 불러주세요 :fairy-wand:');
+	}
+
+	const now = Date.now();
+	let data: Record<string, unknown>;
+
+	try {
+		const parsed = JSON.parse(checkIn);
+		data = typeof parsed === 'object' && parsed.time ? parsed : { time: parseInt(checkIn) };
+	} catch {
+		data = { time: parseInt(checkIn) };
+	}
+
+	if (data.pausedAt) {
+		const pauseElapsed = formatDuration(now - (data.pausedAt as number));
+		return replyEphemeral(`:fairy-moon: 이미 일시정지 중이에요! (${pauseElapsed} 경과)\n/resume으로 다시 시작해주세요!`);
+	}
+
+	data.pausedAt = now;
+	await env.STUDY_KV.put(`${teamId}:checkin:${userId}`, JSON.stringify(data));
+
+	const elapsed = formatDuration(now - (data.time as number) - ((data.totalPauseDuration as number) || 0));
+	const publicMessage = `:fairy-moon: <@${userId}>님이 잠시 쉬어가요! (${formatTime(now)}, 집중 ${elapsed})`;
+
+	const posted = await postMessage(env, teamId, channelId, publicMessage);
+	if (posted) {
+		return replyEphemeral(':fairy-moon: 일시정지! 쉬고 올 때 /resume 해주세요');
+	} else {
+		return reply(publicMessage);
+	}
+}
+
+export async function handleResume(
+	env: Env,
+	teamId: string,
+	userId: string,
+	channelId: string
+): Promise<Response> {
+	const checkIn = await env.STUDY_KV.get(`${teamId}:checkin:${userId}`);
+
+	if (!checkIn) {
+		return replyEphemeral('아직 시작 전이에요! /start로 요정을 불러주세요 :fairy-wand:');
+	}
+
+	const now = Date.now();
+	let data: Record<string, unknown>;
+
+	try {
+		const parsed = JSON.parse(checkIn);
+		data = typeof parsed === 'object' && parsed.time ? parsed : { time: parseInt(checkIn) };
+	} catch {
+		data = { time: parseInt(checkIn) };
+	}
+
+	if (!data.pausedAt) {
+		return replyEphemeral(':fairy-wand: 일시정지 상태가 아니에요! 집중 중입니다 :fairy-hourglass:');
+	}
+
+	const pauseDuration = now - (data.pausedAt as number);
+	data.totalPauseDuration = ((data.totalPauseDuration as number) || 0) + pauseDuration;
+	delete data.pausedAt;
+	await env.STUDY_KV.put(`${teamId}:checkin:${userId}`, JSON.stringify(data));
+
+	const publicMessage = `:fairy-wand: <@${userId}>님이 다시 집중을 시작했어요! (${formatTime(now)}, 휴식 ${formatDuration(pauseDuration)})`;
+
+	const posted = await postMessage(env, teamId, channelId, publicMessage);
+	if (posted) {
+		return replyEphemeral(`:fairy-wand: 다시 집중! (휴식 ${formatDuration(pauseDuration)})`);
+	} else {
+		return reply(publicMessage);
+	}
+}

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -26,13 +26,22 @@ export async function handleStart(
 
 	if (existing) {
 		let startTime: number;
+		let isPaused = false;
 		try {
 			const parsed = JSON.parse(existing);
-			startTime = typeof parsed === 'object' && parsed.time ? parsed.time : parseInt(existing);
+			if (typeof parsed === 'object' && parsed.time) {
+				startTime = parsed.time;
+				isPaused = !!parsed.pausedAt;
+			} else {
+				startTime = parseInt(existing);
+			}
 		} catch {
 			startTime = parseInt(existing);
 		}
 		const elapsed = formatDuration(now - startTime);
+		if (isPaused) {
+			return replyEphemeral(`:fairy-moon: 일시정지 중이에요! /resume으로 다시 시작하거나 /end로 종료해주세요 (${elapsed} 경과)`);
+		}
 		return replyEphemeral(`이미 집중 중이에요! 요정이 지켜보고 있어요 :fairy-hourglass: (${elapsed} 경과)`);
 	}
 
@@ -100,13 +109,22 @@ async function handleStartPlan(
 	const existing = await env.STUDY_KV.get(`${teamId}:checkin:${userId}`);
 	if (existing) {
 		let startTime: number;
+		let isPaused = false;
 		try {
 			const parsed = JSON.parse(existing);
-			startTime = typeof parsed === 'object' && parsed.time ? parsed.time : parseInt(existing);
+			if (typeof parsed === 'object' && parsed.time) {
+				startTime = parsed.time;
+				isPaused = !!parsed.pausedAt;
+			} else {
+				startTime = parseInt(existing);
+			}
 		} catch {
 			startTime = parseInt(existing);
 		}
 		const elapsed = formatDuration(Date.now() - startTime);
+		if (isPaused) {
+			return replyEphemeral(`:fairy-moon: 일시정지 중이에요! /resume으로 다시 시작하거나 /end로 종료해주세요 (${elapsed} 경과)`);
+		}
 		return replyEphemeral(`이미 집중 중이에요! 요정이 지켜보고 있어요 :fairy-hourglass: (${elapsed} 경과)`);
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import {
 	handleExport,
 	handlePattern,
 	handleCheer,
+	handlePause,
+	handleResume,
 } from './commands';
 import { reply } from './utils/slack';
 import { handleLanding } from './pages/landing/index';
@@ -72,9 +74,13 @@ export default {
 				return handleExport(env, teamId, userId, channelId, text);
 			case '/pattern':
 				return handlePattern(env, teamId, userId, text);
-			case '/cheer':
-				return handleCheer(env, teamId, userId, channelId, text);
-			default:
+		case '/cheer':
+			return handleCheer(env, teamId, userId, channelId, text);
+		case '/pause':
+			return handlePause(env, teamId, userId, channelId);
+		case '/resume':
+			return handleResume(env, teamId, userId, channelId);
+		default:
 				return reply('알 수 없는 명령어예요.');
 		}
 	},

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,7 @@ export interface Session {
 	label?: string;
 	checked?: boolean[];
 	tag?: string;
+	pauseDuration?: number;
 }
 
 /** 날짜 범위 (리포트용) */


### PR DESCRIPTION
## Summary
- `/pause` — 집중 세션 일시정지 (KV에 `pausedAt` 타임스탬프 기록)
- `/resume` — 일시정지된 세션 재개 (휴식 시간 `totalPauseDuration`에 누적)
- `/end` — 총 집중 시간에서 휴식 시간 자동 차감 + 종료 메시지에 "(휴식 X분 제외)" 표시
- `/start` — 일시정지 중 `/start` 시도 시 `/resume` 또는 `/end` 안내 메시지

## 동작 흐름
start → 집중 시작
/pause → :fairy-moon: 일시정지 (휴식 시작)
/resume → :fairy-wand: 다시 집중 (휴식 시간 누적)
/end → 집중 시간에서 휴식 시간 차감하여 기록

## 변경 파일
| 파일 | 내용 |
|------|------|
| `src/commands/pause.ts` | `/pause`, `/resume` 핸들러 (신규) |
| `src/commands/end.ts` | `totalPauseDuration` 차감 + 메시지 표시 |
| `src/commands/start.ts` | 일시정지 상태 안내 메시지 |
| `src/index.ts` | `/pause`, `/resume` 라우팅 추가 |
| `src/commands/index.ts` | export 추가 |
| `src/types/index.ts` | `Session`에 `pauseDuration` 필드 추가 |

## 엣지 케이스 처리
- 일시정지 중 `/pause` → "이미 일시정지 중" 안내
- 집중 중 `/resume` → "일시정지 상태가 아니에요" 안내
- 일시정지 중 `/end` → 마지막 휴식 포함하여 차감 후 정상 종료
- 일시정지 중 `/start` → `/resume` 또는 `/end` 안내

Closes #42