### PR TITLE
[FEAT/#44] /end 6시간 초과 시 "그대로 기록하기" 확인 버튼

### DIFF
--- a/src/commands/end.ts
+++ b/src/commands/end.ts
@@ -10,21 +10,17 @@ import { getWeekTotalForDate } from '../services/session';
 import { ENCOURAGEMENTS, MAX_AUTO_DURATION, SESSION_TAGS } from '../constants/messages';
 import { buildFinalChecklistBlocks } from '../interactions';
 
-export async function handleEnd(
-	env: Env,
-	teamId: string,
-	userId: string,
-	channelId: string,
-	text: string
-): Promise<Response> {
-	const checkIn = await env.STUDY_KV.get(`${teamId}:checkin:${userId}`);
+interface CheckinData {
+	startTime: number;
+	label?: string;
+	checked?: boolean[];
+	tag?: string;
+	messageTs?: string;
+	msgChannelId?: string;
+	totalPauseDuration: number;
+}
 
-	if (!checkIn) {
-		return replyEphemeral('아직 시작 전이에요! /start로 요정을 불러주세요 :fairy-wand:');
-	}
-
-	const now = Date.now();
-
+function parseCheckinData(checkIn: string, now: number): CheckinData {
 	let startTime: number;
 	let label: string | undefined;
 	let checked: boolean[] | undefined;
@@ -32,7 +28,7 @@ export async function handleEnd(
 	let messageTs: string | undefined;
 	let msgChannelId: string | undefined;
 	let totalPauseDuration = 0;
-	let wasPaused = false;
+
 	try {
 		const parsed = JSON.parse(checkIn);
 		if (typeof parsed === 'object' && parsed.time) {
@@ -45,7 +41,6 @@ export async function handleEnd(
 			totalPauseDuration = parsed.totalPauseDuration || 0;
 			if (parsed.pausedAt) {
 				totalPauseDuration += now - parsed.pausedAt;
-				wasPaused = true;
 			}
 		} else {
 			startTime = parseInt(checkIn);
@@ -54,29 +49,21 @@ export async function handleEnd(
 		startTime = parseInt(checkIn);
 	}
 
-	let duration = now - startTime - totalPauseDuration;
+	return { startTime, label, checked, tag, messageTs, msgChannelId, totalPauseDuration };
+}
 
-	// 6시간 초과 + 시간 입력 없으면 경고 (본인에게만)
-	if (duration > MAX_AUTO_DURATION && !text) {
-		let warningMsg = `:fairy-zzz: ${formatDuration(duration)} 기록 예정!`;
-		if (totalPauseDuration > 0) {
-			warningMsg += ` (중간 휴식 ${formatDuration(totalPauseDuration)}을 제외했어요!)`;
-		}
-		warningMsg += `\n실제 집중 시간과 다르다면 요정이 고쳐드릴게요\n`;
-		warningMsg += `\n👉 이렇게 입력해보세요: /end 2시간 30분`;
-		return replyEphemeral(warningMsg);
-	}
+/** 세션 종료 핵심 로직 — /end 커맨드와 "그대로 기록하기" 버튼 공용 */
+export async function completeEndSession(
+	env: Env,
+	teamId: string,
+	userId: string,
+	channelId: string,
+	duration: number,
+	checkin: CheckinData
+): Promise<string> {
+	const now = Date.now();
+	const { startTime, label, checked, tag, messageTs, msgChannelId, totalPauseDuration } = checkin;
 
-	// 시간 직접 입력한 경우
-	if (text) {
-		const parsed = parseDuration(text);
-		if (parsed === null) {
-			return replyEphemeral('시간 형식을 확인해주세요! 예: /end 2시간 30분');
-		}
-		duration = parsed;
-	}
-
-	// 개별 세션 저장 (시작 시간 기준으로 저장)
 	const sessionDate = getDateKey(startTime);
 	const sessionsKey = `${teamId}:sessions:${sessionDate}`;
 	const sessions: Session[] = JSON.parse((await env.STUDY_KV.get(sessionsKey)) || '[]');
@@ -88,14 +75,12 @@ export async function handleEnd(
 	sessions.push(session);
 	await env.STUDY_KV.put(sessionsKey, JSON.stringify(sessions));
 
-	// 전체 누적도 유지
 	const totalRecords: Record<string, number> = JSON.parse((await env.STUDY_KV.get(`${teamId}:total`)) || '{}');
 	totalRecords[userId] = (totalRecords[userId] || 0) + duration;
 	await env.STUDY_KV.put(`${teamId}:total`, JSON.stringify(totalRecords));
 
 	await env.STUDY_KV.delete(`${teamId}:checkin:${userId}`);
 
-	// 체크리스트 메시지가 있으면 버튼 제거한 최종 상태로 업데이트
 	if (messageTs && msgChannelId && label && checked) {
 		const tagLabel = tag ? (SESSION_TAGS.find(t => t.value === tag)?.label || '기타') : undefined;
 		const items = label.split('\n').filter((l: string) => l.trim()).map((l: string) => l.trim());
@@ -103,15 +88,8 @@ export async function handleEnd(
 		await updateMessage(env, teamId, msgChannelId, messageTs, '', finalBlocks);
 	}
 
-	// 세션이 저장된 주의 누적 계산
 	const weekTotal = await getWeekTotalForDate(env, teamId, userId, startTime);
-
-	// 이번 주인지 지난 주인지 판단
 	const weekLabel = isCurrentWeek(startTime) ? '이번 주' : '지난 주';
-
-	// 사용자 이름 조회
-	const userName = await getUserName(env, teamId, userId);
-
 	const randomMsg = ENCOURAGEMENTS[Math.floor(Math.random() * ENCOURAGEMENTS.length)];
 
 	const tagLabel = tag ? (SESSION_TAGS.find(t => t.value === tag)?.label || '기타') : undefined;
@@ -135,14 +113,74 @@ export async function handleEnd(
 	}
 	publicMessage += `\n\n${randomMsg}`;
 
-	// 채널에 공개 메시지 전송 시도
-	const posted = await postMessage(env, teamId, channelId, publicMessage);
+	await postMessage(env, teamId, channelId, publicMessage);
+	return formatDuration(duration);
+}
 
-	if (posted) {
-		// postMessage 성공: 본인에게만 짧은 확인 메시지
-		return replyEphemeral(`:fairy-party: ${formatDuration(duration)} 기록 완료!`);
-	} else {
-		// postMessage 실패: 기존 방식으로 fallback (in_channel)
-		return reply(publicMessage);
+export async function handleEnd(
+	env: Env,
+	teamId: string,
+	userId: string,
+	channelId: string,
+	text: string
+): Promise<Response> {
+	const checkIn = await env.STUDY_KV.get(`${teamId}:checkin:${userId}`);
+
+	if (!checkIn) {
+		return replyEphemeral('아직 시작 전이에요! /start로 요정을 불러주세요 :fairy-wand:');
 	}
+
+	const now = Date.now();
+	const checkin = parseCheckinData(checkIn, now);
+	let duration = now - checkin.startTime - checkin.totalPauseDuration;
+
+	// 6시간 초과 + 시간 입력 없으면 경고 + 확인 버튼 (본인에게만)
+	if (duration > MAX_AUTO_DURATION && !text) {
+		let warningMsg = `:fairy-zzz: ${formatDuration(duration)} 기록 예정!`;
+		if (checkin.totalPauseDuration > 0) {
+			warningMsg += ` (중간 휴식 ${formatDuration(checkin.totalPauseDuration)}을 제외했어요!)`;
+		}
+		warningMsg += `\n실제 집중 시간과 다르다면 요정이 고쳐드릴게요`;
+
+		const buttonValue = JSON.stringify({ channelId, duration });
+
+		return new Response(JSON.stringify({
+			response_type: 'ephemeral',
+			text: warningMsg,
+			blocks: [
+				{
+					type: 'section',
+					text: { type: 'mrkdwn', text: warningMsg },
+				},
+				{
+					type: 'actions',
+					elements: [
+						{
+							type: 'button',
+							text: { type: 'plain_text', text: `✅ ${formatDuration(duration)} 그대로 기록하기` },
+							action_id: 'confirm_end_duration',
+							value: buttonValue,
+							style: 'primary',
+						},
+					],
+				},
+				{
+					type: 'context',
+					elements: [{ type: 'mrkdwn', text: '👉 다르다면: `/end 2시간 30분`' }],
+				},
+			],
+		}), { headers: { 'Content-Type': 'application/json' } });
+	}
+
+	// 시간 직접 입력한 경우
+	if (text) {
+		const parsed = parseDuration(text);
+		if (parsed === null) {
+			return replyEphemeral('시간 형식을 확인해주세요! 예: /end 2시간 30분');
+		}
+		duration = parsed;
+	}
+
+	const durationLabel = await completeEndSession(env, teamId, userId, channelId, duration, checkin);
+	return replyEphemeral(`:fairy-party: ${durationLabel} 기록 완료!`);
 }

--- a/src/interactions/index.ts
+++ b/src/interactions/index.ts
@@ -7,6 +7,7 @@ import { postMessage, updateMessage, getBotToken, postEphemeral } from '../utils
 import { formatTime } from '../utils/format';
 import { getTodayKey } from '../utils/date';
 import { SESSION_TAGS, DEFAULT_TAG } from '../constants/messages';
+import { completeEndSession } from '../commands/end';
 
 interface SlackBlock {
 	type: string;
@@ -83,6 +84,10 @@ async function handleBlockActions(payload: SlackInteractionPayload, env: Env): P
 
 	if (actionId?.startsWith('toggle_check_')) {
 		return handleToggleCheck(payload, env);
+	}
+
+	if (actionId === 'confirm_end_duration') {
+		return handleConfirmEndDuration(payload, env);
 	}
 
 	return new Response('', { status: 200 });
@@ -493,6 +498,53 @@ async function handleToggleCheck(payload: SlackInteractionPayload, env: Env): Pr
 	const tagLabel = tag ? (SESSION_TAGS.find(t => t.value === tag)?.label || '기타') : undefined;
 	const updatedBlocks = buildChecklistBlocks(userId, startTime, items, checked, tagLabel);
 	await updateMessage(env, user.team_id, channel.id, message.ts, message.text, updatedBlocks);
+
+	return new Response('', { status: 200 });
+}
+
+/** "그대로 기록하기" 버튼 클릭 → 세션 종료 처리 */
+async function handleConfirmEndDuration(payload: SlackInteractionPayload, env: Env): Promise<Response> {
+	const { user, actions } = payload;
+	if (!actions?.[0]?.value) {
+		return new Response('', { status: 200 });
+	}
+
+	const { channelId, duration } = JSON.parse(actions[0].value);
+	const teamId = user.team_id;
+	const userId = user.id;
+
+	const checkIn = await env.STUDY_KV.get(`${teamId}:checkin:${userId}`);
+	if (!checkIn) {
+		await postEphemeral(env, teamId, channelId, userId, ':fairy-zzz: 이미 종료된 세션이에요!');
+		return new Response('', { status: 200 });
+	}
+
+	const now = Date.now();
+	let checkinData: Record<string, unknown>;
+	try {
+		const parsed = JSON.parse(checkIn);
+		checkinData = typeof parsed === 'object' && parsed.time ? parsed : { time: parseInt(checkIn) };
+	} catch {
+		checkinData = { time: parseInt(checkIn) };
+	}
+
+	let totalPauseDuration = (checkinData.totalPauseDuration as number) || 0;
+	if (checkinData.pausedAt) {
+		totalPauseDuration += now - (checkinData.pausedAt as number);
+	}
+
+	const checkin = {
+		startTime: checkinData.time as number,
+		label: checkinData.label as string | undefined,
+		checked: checkinData.checked as boolean[] | undefined,
+		tag: checkinData.tag as string | undefined,
+		messageTs: checkinData.messageTs as string | undefined,
+		msgChannelId: checkinData.channelId as string | undefined,
+		totalPauseDuration,
+	};
+
+	const durationLabel = await completeEndSession(env, teamId, userId, channelId, duration, checkin);
+	await postEphemeral(env, teamId, channelId, userId, `:fairy-party: ${durationLabel} 기록 완료!`);
 
 	return new Response('', { status: 200 });
 }


### PR DESCRIPTION
## Summary
- `/end` 시 6시간 초과 경고를 텍스트 → 블록 메시지 + 확인 버튼으로 개선
- "✅ 7시간 30분 그대로 기록하기" 버튼 클릭 시 자동 계산된 시간으로 즉시 종료
- `/pause` 사용 시 휴식 시간 차감 정보도 함께 표시

## 동작 흐름
```
/end (6시간 초과)
→ :fairy-zzz: 9분 기록 예정! (중간 휴식 X분을 제외했어요!)
  실제 집중 시간과 다르다면 요정이 고쳐드릴게요
  [✅ 9분 그대로 기록하기]
  👉 다르다면: /end 2시간 30분

버튼 클릭 → 세션 종료 + 채널에 공개 메시지
```

## 변경 파일
| 파일 | 내용 |
|------|------|
| `src/commands/end.ts` | 세션 종료 로직을 `completeEndSession`으로 추출, 6시간 초과 시 블록+버튼 응답 |
| `src/interactions/index.ts` | `confirm_end_duration` 버튼 클릭 핸들러 추가 |

## 기술 포인트
- 세션 종료 로직을 `completeEndSession()`으로 분리하여 `/end` 커맨드와 버튼 클릭 핸들러가 공용으로 사용
- 버튼 `value`에 `{ channelId, duration }` JSON으로 전달하여 클릭 시점이 아닌 경고 시점의 duration 사용
- 이미 종료된 세션에 버튼 클릭 시 "이미 종료된 세션" 안내

Closes #44