### PR TITLE
[FEAT/#46] /settings 워크스페이스 설정 모달

### DIFF
--- a/src/commands/end.ts
+++ b/src/commands/end.ts
@@ -7,8 +7,9 @@ import { reply, replyEphemeral, postMessage, updateMessage, getUserName } from '
 import { formatTime, formatDuration, parseDuration } from '../utils/format';
 import { getDateKey, isCurrentWeek } from '../utils/date';
 import { getWeekTotalForDate } from '../services/session';
-import { ENCOURAGEMENTS, MAX_AUTO_DURATION, SESSION_TAGS } from '../constants/messages';
+import { ENCOURAGEMENTS, SESSION_TAGS } from '../constants/messages';
 import { buildFinalChecklistBlocks } from '../interactions';
+import { getWorkspaceSettings } from './settings';
 
 interface CheckinData {
 	startTime: number;
@@ -134,8 +135,10 @@ export async function handleEnd(
 	const checkin = parseCheckinData(checkIn, now);
 	let duration = now - checkin.startTime - checkin.totalPauseDuration;
 
-	// 6시간 초과 + 시간 입력 없으면 경고 + 확인 버튼 (본인에게만)
-	if (duration > MAX_AUTO_DURATION && !text) {
+	const settings = await getWorkspaceSettings(env, teamId);
+
+	// 임계값 초과 + 시간 입력 없으면 경고 + 확인 버튼 (본인에게만)
+	if (duration > settings.maxAutoDuration && !text) {
 		let warningMsg = `:fairy-zzz: ${formatDuration(duration)} 기록 예정!`;
 		if (checkin.totalPauseDuration > 0) {
 			warningMsg += ` (중간 휴식 ${formatDuration(checkin.totalPauseDuration)}을 제외했어요!)`;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -11,3 +11,4 @@ export { handleExport } from './export';
 export { handlePattern } from './pattern';
 export { handleCheer } from './cheer';
 export { handlePause, handleResume } from './pause';
+export { handleSettings } from './settings';

--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -1,0 +1,86 @@
+/**
+ * /settings 커맨드 핸들러
+ * 워크스페이스 설정 모달
+ */
+
+import { replyEphemeral, getBotToken } from '../utils/slack';
+import { MAX_AUTO_DURATION } from '../constants/messages';
+
+export interface WorkspaceSettings {
+	maxAutoDuration: number;
+}
+
+const DEFAULT_SETTINGS: WorkspaceSettings = {
+	maxAutoDuration: MAX_AUTO_DURATION,
+};
+
+/** KV에서 워크스페이스 설정 조회 */
+export async function getWorkspaceSettings(env: Env, teamId: string): Promise<WorkspaceSettings> {
+	try {
+		const raw = await env.STUDY_KV.get(`${teamId}:settings`);
+		if (raw) {
+			return { ...DEFAULT_SETTINGS, ...JSON.parse(raw) };
+		}
+	} catch {}
+	return { ...DEFAULT_SETTINGS };
+}
+
+export async function handleSettings(
+	env: Env,
+	teamId: string,
+	triggerId: string
+): Promise<Response> {
+	if (!triggerId) {
+		return replyEphemeral('모달을 열 수 없어요. 다시 시도해주세요!');
+	}
+
+	const token = await getBotToken(env, teamId);
+	if (!token) {
+		return replyEphemeral('봇 토큰을 찾을 수 없어요.');
+	}
+
+	const settings = await getWorkspaceSettings(env, teamId);
+	const currentHours = String(settings.maxAutoDuration / (60 * 60 * 1000));
+
+	const modal = {
+		trigger_id: triggerId,
+		view: {
+			type: 'modal',
+			callback_id: 'settings_modal',
+			title: { type: 'plain_text', text: '⚙️ 워크스페이스 설정' },
+			submit: { type: 'plain_text', text: '저장!' },
+			close: { type: 'plain_text', text: '취소' },
+			blocks: [
+				{
+					type: 'input',
+					block_id: 'max_duration_block',
+					label: { type: 'plain_text', text: ':fairy-hourglass: 자동 기록 임계값 (시간)' },
+					element: {
+						type: 'plain_text_input',
+						action_id: 'max_duration_input',
+						initial_value: currentHours,
+						placeholder: { type: 'plain_text', text: '6' },
+					},
+					hint: { type: 'plain_text', text: '이 시간을 초과하면 /end 시 확인 버튼이 표시됩니다 (1~24시간)' },
+				},
+			],
+		},
+	};
+
+	const res = await fetch('https://slack.com/api/views.open', {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${token}`,
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify(modal),
+	});
+
+	const data = (await res.json()) as { ok: boolean; error?: string };
+	if (!data.ok) {
+		console.error('Failed to open settings modal:', data.error);
+		return replyEphemeral('모달을 열 수 없어요. 다시 시도해주세요!');
+	}
+
+	return new Response('', { status: 200 });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
 	handleCheer,
 	handlePause,
 	handleResume,
+	handleSettings,
 } from './commands';
 import { reply } from './utils/slack';
 import { handleLanding } from './pages/landing/index';
@@ -80,6 +81,8 @@ export default {
 			return handlePause(env, teamId, userId, channelId);
 		case '/resume':
 			return handleResume(env, teamId, userId, channelId);
+		case '/settings':
+			return handleSettings(env, teamId, triggerId);
 		default:
 				return reply('알 수 없는 명령어예요.');
 		}

--- a/src/interactions/index.ts
+++ b/src/interactions/index.ts
@@ -65,6 +65,8 @@ async function handleViewSubmission(payload: SlackInteractionPayload, env: Env):
 			return handleButtonPlanSubmission(user.id, user.team_id, view, env);
 		case 'edit_plan_modal':
 			return handleEditPlanSubmission(user.id, user.team_id, view, env);
+		case 'settings_modal':
+			return handleSettingsSubmission(user.id, user.team_id, view, env);
 		default:
 			return new Response('', { status: 200 });
 	}
@@ -498,6 +500,38 @@ async function handleToggleCheck(payload: SlackInteractionPayload, env: Env): Pr
 	const tagLabel = tag ? (SESSION_TAGS.find(t => t.value === tag)?.label || '기타') : undefined;
 	const updatedBlocks = buildChecklistBlocks(userId, startTime, items, checked, tagLabel);
 	await updateMessage(env, user.team_id, channel.id, message.ts, message.text, updatedBlocks);
+
+	return new Response('', { status: 200 });
+}
+
+/** 설정 모달 제출 핸들러 */
+async function handleSettingsSubmission(
+	userId: string,
+	teamId: string,
+	view: NonNullable<SlackInteractionPayload['view']>,
+	env: Env
+): Promise<Response> {
+	const hoursStr = view.state.values['max_duration_block']?.['max_duration_input']?.value?.trim();
+	const hours = parseFloat(hoursStr || '');
+
+	if (isNaN(hours) || hours < 1 || hours > 24) {
+		return new Response(JSON.stringify({
+			response_action: 'errors',
+			errors: { max_duration_block: '1~24 사이의 숫자를 입력해주세요' },
+		}), { headers: { 'Content-Type': 'application/json' } });
+	}
+
+	const maxAutoDuration = Math.round(hours * 60 * 60 * 1000);
+
+	const settingsKey = `${teamId}:settings`;
+	let settings: Record<string, unknown> = {};
+	try {
+		const raw = await env.STUDY_KV.get(settingsKey);
+		if (raw) settings = JSON.parse(raw);
+	} catch {}
+
+	settings.maxAutoDuration = maxAutoDuration;
+	await env.STUDY_KV.put(settingsKey, JSON.stringify(settings));
 
 	return new Response('', { status: 200 });
 }


### PR DESCRIPTION
## Summary
- `/settings` 커맨드로 워크스페이스 설정 모달 오픈
- 첫 번째 설정 항목: 자동 기록 임계값 (기본 6시간, 1~24시간 커스텀 가능)
- `/end` 시 하드코딩 값 대신 워크스페이스별 설정값을 참조

## 동작 흐름
```
/settings
→ 모달 오픈 (현재 설정값 표시)
→ 자동 기록 임계값 입력 (예: 8)
→ 저장!
→ KV에 {teamId}:settings 저장

/end (임계값 초과 시)
→ 워크스페이스 설정값 기준으로 확인 버튼 표시
```

## 변경 파일
| 파일 | 내용 |
|------|------|
| `src/commands/settings.ts` | `/settings` 핸들러 + `getWorkspaceSettings` 유틸 (신규) |
| `src/commands/end.ts` | `MAX_AUTO_DURATION` → `getWorkspaceSettings()` 참조 |
| `src/interactions/index.ts` | `settings_modal` 제출 핸들러 + 입력 검증 |
| `src/index.ts` | `/settings` 라우팅 추가 |
| `src/commands/index.ts` | export 추가 |

## 기술 포인트
- KV 구조: `{teamId}:settings` → `{ "maxAutoDuration": 21600000 }`
- 설정 미등록 워크스페이스는 기본값(6시간) 자동 적용
- 향후 타임존, 점심시간 등 설정 항목 추가 시 같은 키에 필드 추가 가능

Closes #46