### PR TITLE
[FIX/#60] /mystats pause 중 NaN 표시 수정

### DIFF
--- a/src/commands/mystats.ts
+++ b/src/commands/mystats.ts
@@ -15,8 +15,33 @@ export async function handleMyStats(env: Env, teamId: string, userId: string): P
 
 	let status = ':fairy-coffee: 현재 쉬는 중';
 	if (checkIn) {
-		const elapsed = Date.now() - parseInt(checkIn);
-		status = `:fairy-fire: 집중 중 (${formatDuration(elapsed)} 경과)`;
+		const now = Date.now();
+		let startTime: number;
+		let totalPauseDuration = 0;
+		let isPaused = false;
+
+		try {
+			const parsed = JSON.parse(checkIn);
+			if (typeof parsed === 'object' && parsed.time) {
+				startTime = parsed.time;
+				totalPauseDuration = parsed.totalPauseDuration || 0;
+				isPaused = !!parsed.pausedAt;
+				if (isPaused) {
+					totalPauseDuration += now - parsed.pausedAt;
+				}
+			} else {
+				startTime = parseInt(checkIn);
+			}
+		} catch {
+			startTime = parseInt(checkIn);
+		}
+
+		const elapsed = now - startTime - totalPauseDuration;
+		if (isPaused) {
+			status = `:fairy-moon: 일시정지 중 (${formatDuration(elapsed)} 경과)`;
+		} else {
+			status = `:fairy-fire: 집중 중 (${formatDuration(elapsed)} 경과)`;
+		}
 	}
 
 	return replyEphemeral(

--- a/src/commands/mystats.ts
+++ b/src/commands/mystats.ts
@@ -38,7 +38,7 @@ export async function handleMyStats(env: Env, teamId: string, userId: string): P
 
 		const elapsed = now - startTime - totalPauseDuration;
 		if (isPaused) {
-			status = `:fairy-moon: 일시정지 중 (${formatDuration(elapsed)} 경과)`;
+			status = `:fairy-moon: 일시정지 중 (집중 ${formatDuration(elapsed)})`;
 		} else {
 			status = `:fairy-fire: 집중 중 (${formatDuration(elapsed)} 경과)`;
 		}

--- a/src/pages/landing/data.ts
+++ b/src/pages/landing/data.ts
@@ -136,8 +136,23 @@ export async function collectTeamStats(env: Env, teamId: string, weekInfo: WeekI
 		);
 		checkinList.keys.forEach((key, idx) => {
 			const userId = key.name.replace(`${teamId}:checkin:`, '');
-			const startTime = parseInt(checkinValues[idx] || '0');
-			const currentSessionDuration = startTime > 0 ? Date.now() - startTime : 0;
+			let startTime = 0;
+			let totalPauseDuration = 0;
+			try {
+				const parsed = JSON.parse(checkinValues[idx] || '0');
+				if (typeof parsed === 'object' && parsed.time) {
+					startTime = parsed.time;
+					totalPauseDuration = parsed.totalPauseDuration || 0;
+					if (parsed.pausedAt) {
+						totalPauseDuration += Date.now() - parsed.pausedAt;
+					}
+				} else {
+					startTime = parseInt(checkinValues[idx] || '0');
+				}
+			} catch {
+				startTime = parseInt(checkinValues[idx] || '0');
+			}
+			const currentSessionDuration = startTime > 0 ? Date.now() - startTime - totalPauseDuration : 0;
 
 			const existing = statsMap.get(userId);
 			if (existing) {


### PR DESCRIPTION
## Summary
- `/mystats`에서 pause 중일 때 "NaN분 경과" 표시되던 버그 수정
- checkin 데이터 JSON 파싱 처리 (기존 `parseInt`만 사용)
- 일시정지 상태일 때 "일시정지 중 (집중 n분)"으로 구분 표시
- 랜딩 페이지(`landing/data.ts`)에서도 동일한 잠재적 버그 수정

<img width="589" height="227" alt="image" src="https://github.com/user-attachments/assets/d17a3073-dbf6-4880-b456-3e11f0cd41a3" />

## Test plan
- [x] `/start` → `/pause` → `/mystats` → "일시정지 중 (집중 n분)" 표시 확인
- [x] `/start` → `/mystats` → "집중 중 (n분 경과)" 정상 표시
- [x] `/start` → `/pause` → `/resume` → `/mystats` → pause 시간 제외된 집중 시간 확인
- [x] 랜딩 페이지에서 pause 중인 유저 시간 정상 표시

Closes #60