### PR TITLE
[FEAT/#62] 집중 상태를 Slack status에 자동 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 | `/pattern`  | 집중 패턴 분석 (`time`, `day`, 월별 조회: `26-02`)                       |
 | `/cheer`    | 팀원에게 :fairy-coffee: 응원 보내기 (`leaderboard`, `leaderboard received`) |
 | `/settings` | 워크스페이스 설정 (자동 기록 임계값, 기본 시간대, 라벨 표시 모드)        |
+| `/settings sync` | Slack status 자동 동기화 연결/해제                                  |
 
 ## 🛠 기술 스택
 
@@ -63,11 +64,35 @@ echo '{"TEAM_ID_1":"xoxb-...", "TEAM_ID_2":"xoxb-..."}' | npx wrangler secret pu
 - **팀원 응원** — `/cheer @팀원`으로 :fairy-coffee: 커피 보내기 (하루 5잔 제한, 주간 랭킹)
 - **일시정지/재개** — `/pause`로 휴식, `/resume`으로 재개 (휴식 시간 자동 차감)
 - **워크스페이스 설정** — `/settings`로 자동 기록 임계값, 기본 시간대, 라벨 모드 관리
+- **Slack status 동기화** — `/start`, `/pause`, `/end` 시 Slack status 자동 변경 (opt-in)
 - **세션 소유자 가드** — 타인의 체크리스트/버튼 조작 방지
 
 ---
 
 # 📋 릴리즈 노트
+
+## [1.14.0] - 2026-05-01
+
+### ✨ 새로운 기능
+
+- **Slack status 자동 동기화** — 집중 세션 상태를 Slack status에 자동 반영
+  - `/start` → 💻 집중 중
+  - `/pause` → ☕ 잠깐 자리비움
+  - `/resume` → 💻 집중 중 복귀
+  - `/end` → status 초기화
+  - 사용자 개별 OAuth 동의 방식 (opt-in) — 기존 사용자 영향 없음
+- **`/settings sync`** — Slack status 동기화 연결/해제 관리
+  - 연결 상태 확인, OAuth 권한 연결, 연결 해제
+- **`/help` 업데이트** — `/settings sync` 명령어 안내 추가
+
+### 🔧 기술 개선
+
+- User OAuth 플로우 추가 (`/slack/oauth/user-install`, `/slack/oauth/user-callback`)
+- `users.profile:write` User Token Scope로 Slack status 변경
+- `setUserStatus`, `clearUserStatus` 유틸 함수 추가
+- 토큰 무효화 시 자동 정리 (`token_revoked`, `invalid_auth` 감지)
+
+---
 
 ## [1.12.0] - 2026-03-24
 

--- a/src/commands/end.ts
+++ b/src/commands/end.ts
@@ -92,7 +92,7 @@ export async function completeEndSession(
 
 	await env.STUDY_KV.delete(`${teamId}:checkin:${userId}`);
 
-	clearUserStatus(env, teamId, userId);
+	await clearUserStatus(env, teamId, userId);
 
 	if (messageTs && msgChannelId && label && checked) {
 		const tagLabel = tag ? (SESSION_TAGS.find(t => t.value === tag)?.label || '기타') : undefined;

--- a/src/commands/end.ts
+++ b/src/commands/end.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Session } from '../types';
-import { reply, replyEphemeral, postMessage, updateMessage, getUserName } from '../utils/slack';
+import { reply, replyEphemeral, postMessage, updateMessage, getUserName, clearUserStatus } from '../utils/slack';
 import { formatTime, formatDuration, parseDuration, calcLunchDeduction } from '../utils/format';
 import { getDateKey, isCurrentWeek, isAprilFools } from '../utils/date';
 import { getWeekTotalForDate } from '../services/session';
@@ -91,6 +91,8 @@ export async function completeEndSession(
 	await env.STUDY_KV.put(`${teamId}:total`, JSON.stringify(totalRecords));
 
 	await env.STUDY_KV.delete(`${teamId}:checkin:${userId}`);
+
+	clearUserStatus(env, teamId, userId);
 
 	if (messageTs && msgChannelId && label && checked) {
 		const tagLabel = tag ? (SESSION_TAGS.find(t => t.value === tag)?.label || '기타') : undefined;

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -95,7 +95,8 @@ export async function handleHelp(
 							'  `/cheer leaderboard` — 응원 랭킹\n' +
 							'  `/cheer leaderboard received` — 받은 커피 랭킹\n' +
 							'\n' +
-							'*`/settings`* — 워크스페이스 설정 (모달)',
+							'*`/settings`* — 워크스페이스 설정 (모달)\n' +
+							'  `/settings sync` — Slack status 자동 동기화 연결/해제',
 					},
 				},
 			],

--- a/src/commands/pause.ts
+++ b/src/commands/pause.ts
@@ -37,7 +37,7 @@ export async function handlePause(
 	data.pausedAt = now;
 	await env.STUDY_KV.put(`${teamId}:checkin:${userId}`, JSON.stringify(data));
 
-	setUserStatus(env, teamId, userId, '잠깐 자리비움', ':coffee:');
+	await setUserStatus(env, teamId, userId, '잠깐 자리비움', ':coffee:');
 
 	const tzInfo = await getUserTimezoneInfo(env, teamId, userId);
 	const elapsed = formatDuration(now - (data.time as number) - ((data.totalPauseDuration as number) || 0));
@@ -86,14 +86,15 @@ export async function handleResume(
 	delete data.pausedAt;
 	await env.STUDY_KV.put(`${teamId}:checkin:${userId}`, JSON.stringify(data));
 
-	setUserStatus(env, teamId, userId, '집중 중', ':tomato:');
+	const resumeStatusResult = await setUserStatus(env, teamId, userId, '집중 중', ':computer:');
 
 	const tzInfo = await getUserTimezoneInfo(env, teamId, userId);
 	const publicMessage = `:fairy-wand: <@${userId}>님이 다시 집중을 시작했어요! (${formatTime(now, tzInfo.timezone, tzInfo.showLabel)}, 휴식 ${formatDuration(pauseDuration)})`;
 
 	const posted = await postMessage(env, teamId, channelId, publicMessage);
 	if (posted) {
-		return replyEphemeral(`:fairy-wand: 다시 집중! (휴식 ${formatDuration(pauseDuration)})`);
+		const debugInfo = resumeStatusResult ? '' : ' (status 동기화 실패)';
+		return replyEphemeral(`:fairy-wand: 다시 집중! (휴식 ${formatDuration(pauseDuration)})${debugInfo}`);
 	} else {
 		return reply(publicMessage);
 	}

--- a/src/commands/pause.ts
+++ b/src/commands/pause.ts
@@ -3,7 +3,7 @@
  * 집중 세션 일시정지 / 재개
  */
 
-import { reply, replyEphemeral, postMessage } from '../utils/slack';
+import { reply, replyEphemeral, postMessage, setUserStatus } from '../utils/slack';
 import { formatTime, formatDuration } from '../utils/format';
 import { getUserTimezoneInfo } from './settings';
 
@@ -36,6 +36,8 @@ export async function handlePause(
 
 	data.pausedAt = now;
 	await env.STUDY_KV.put(`${teamId}:checkin:${userId}`, JSON.stringify(data));
+
+	setUserStatus(env, teamId, userId, '잠깐 자리비움', ':coffee:');
 
 	const tzInfo = await getUserTimezoneInfo(env, teamId, userId);
 	const elapsed = formatDuration(now - (data.time as number) - ((data.totalPauseDuration as number) || 0));
@@ -83,6 +85,8 @@ export async function handleResume(
 	data.pausePeriods = periods;
 	delete data.pausedAt;
 	await env.STUDY_KV.put(`${teamId}:checkin:${userId}`, JSON.stringify(data));
+
+	setUserStatus(env, teamId, userId, '집중 중', ':tomato:');
 
 	const tzInfo = await getUserTimezoneInfo(env, teamId, userId);
 	const publicMessage = `:fairy-wand: <@${userId}>님이 다시 집중을 시작했어요! (${formatTime(now, tzInfo.timezone, tzInfo.showLabel)}, 휴식 ${formatDuration(pauseDuration)})`;

--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -3,7 +3,7 @@
  * 워크스페이스 설정 모달
  */
 
-import { replyEphemeral, getBotToken, getUserTimezone } from '../utils/slack';
+import { replyEphemeral, getBotToken, getUserTimezone, getUserToken } from '../utils/slack';
 import { MAX_AUTO_DURATION } from '../constants/messages';
 
 export type TimezoneLabelMode = 'auto' | 'always' | 'never';
@@ -105,8 +105,15 @@ export async function getWorkspaceSettings(env: Env, teamId: string): Promise<Wo
 export async function handleSettings(
 	env: Env,
 	teamId: string,
-	triggerId: string
+	userId: string,
+	triggerId: string,
+	text?: string,
+	baseUrl?: string
 ): Promise<Response> {
+	if (text === 'sync') {
+		return handleSyncSettings(env, teamId, userId, baseUrl);
+	}
+
 	if (!triggerId) {
 		return replyEphemeral('모달을 열 수 없어요. 다시 시도해주세요!');
 	}
@@ -247,4 +254,75 @@ export async function handleSettings(
 	}
 
 	return new Response('', { status: 200 });
+}
+
+async function handleSyncSettings(
+	env: Env,
+	teamId: string,
+	userId: string,
+	baseUrl?: string
+): Promise<Response> {
+	const hasToken = !!(await getUserToken(env, teamId, userId));
+
+	if (hasToken) {
+		return new Response(JSON.stringify({
+			response_type: 'ephemeral',
+			text: '🍅 Slack status 동기화: 연결됨',
+			blocks: [
+				{
+					type: 'section',
+					text: {
+						type: 'mrkdwn',
+						text: '🍅 *Slack status 동기화: 연결됨* ✅\n\n`/start`, `/pause`, `/end` 시 Slack status가 자동으로 변경돼요.',
+					},
+				},
+				{
+					type: 'actions',
+					elements: [
+						{
+							type: 'button',
+							text: { type: 'plain_text', text: '🔌 연결 해제' },
+							action_id: 'disconnect_status_sync',
+							style: 'danger',
+							confirm: {
+								title: { type: 'plain_text', text: '연결 해제' },
+								text: { type: 'plain_text', text: 'Slack status 자동 동기화를 해제할까요?' },
+								confirm: { type: 'plain_text', text: '해제' },
+								deny: { type: 'plain_text', text: '취소' },
+							},
+						},
+					],
+				},
+			],
+		}), { headers: { 'Content-Type': 'application/json' } });
+	}
+
+	const oauthUrl = baseUrl ? `${baseUrl}/slack/oauth/user-install` : '';
+
+	return new Response(JSON.stringify({
+		response_type: 'ephemeral',
+		text: '🍅 Slack status 동기화: 연결 안됨',
+		blocks: [
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: '🍅 *Slack status 동기화*\n\n연결하면 `/start`, `/pause`, `/end` 시 Slack status가 자동으로 변경돼요.\n\n' +
+						'• `/start` → 🍅 집중 중\n• `/pause` → ☕ 잠깐 자리비움\n• `/end` → status 초기화',
+				},
+			},
+			...(oauthUrl ? [{
+				type: 'actions',
+				elements: [
+					{
+						type: 'button',
+						text: { type: 'plain_text', text: '🔗 Slack에서 권한 연결하기' },
+						url: oauthUrl,
+						action_id: 'connect_status_sync',
+						style: 'primary',
+					},
+				],
+			}] : []),
+		],
+	}), { headers: { 'Content-Type': 'application/json' } });
 }

--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -308,7 +308,7 @@ async function handleSyncSettings(
 				text: {
 					type: 'mrkdwn',
 					text: '🍅 *Slack status 동기화*\n\n연결하면 `/start`, `/pause`, `/end` 시 Slack status가 자동으로 변경돼요.\n\n' +
-						'• `/start` → 🍅 집중 중\n• `/pause` → ☕ 잠깐 자리비움\n• `/end` → status 초기화',
+						'• `/start` → 💻 집중 중\n• `/pause` → ☕ 잠깐 자리비움\n• `/end` → status 초기화',
 				},
 			},
 			...(oauthUrl ? [{

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -2,7 +2,7 @@
  * /start 커맨드 핸들러
  */
 
-import { reply, replyEphemeral, postMessage, postMessageWithBlocks, getBotToken } from '../utils/slack';
+import { reply, replyEphemeral, postMessage, postMessageWithBlocks, getBotToken, setUserStatus } from '../utils/slack';
 import { formatTime, formatDuration } from '../utils/format';
 import { getTodayKey, isAprilFools } from '../utils/date';
 import { SESSION_TAGS, DEFAULT_TAG } from '../constants/messages';
@@ -60,6 +60,8 @@ export async function handleStart(
 	const label = text && !RESERVED_SUBCOMMANDS.includes(text) ? text : '';
 	const checkinData = label ? JSON.stringify({ time: now, label }) : now.toString();
 	await env.STUDY_KV.put(`${teamId}:checkin:${userId}`, checkinData);
+
+	setUserStatus(env, teamId, userId, '집중 중', ':tomato:');
 
 	const todayKey = getTodayKey();
 	const todayList: string[] = JSON.parse((await env.STUDY_KV.get(`${teamId}:today:${todayKey}`)) || '[]');

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -61,7 +61,7 @@ export async function handleStart(
 	const checkinData = label ? JSON.stringify({ time: now, label }) : now.toString();
 	await env.STUDY_KV.put(`${teamId}:checkin:${userId}`, checkinData);
 
-	setUserStatus(env, teamId, userId, '집중 중', ':tomato:');
+	await setUserStatus(env, teamId, userId, '집중 중', ':computer:');
 
 	const todayKey = getTodayKey();
 	const todayList: string[] = JSON.parse((await env.STUDY_KV.get(`${teamId}:today:${todayKey}`)) || '[]');

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import {
 } from './commands';
 import { reply } from './utils/slack';
 import { handleLanding } from './pages/landing/index';
-import { handleOAuthInstall, handleOAuthCallback } from './pages/install/index';
+import { handleOAuthInstall, handleOAuthCallback, handleUserOAuthInstall, handleUserOAuthCallback } from './pages/install/index';
 import { handleInteraction } from './interactions';
 
 export default {
@@ -34,6 +34,10 @@ export default {
 					return handleOAuthInstall(env);
 				case '/slack/oauth/callback':
 					return handleOAuthCallback(request, env);
+				case '/slack/oauth/user-install':
+					return handleUserOAuthInstall(request, env);
+				case '/slack/oauth/user-callback':
+					return handleUserOAuthCallback(request, env);
 				default: {
 					const teamId = url.searchParams.get('team') || env.DEFAULT_TEAM_ID;
 					const weekParam = url.searchParams.get('week');
@@ -83,7 +87,7 @@ export default {
 		case '/resume':
 			return handleResume(env, teamId, userId, channelId);
 		case '/settings':
-			return handleSettings(env, teamId, triggerId);
+			return handleSettings(env, teamId, userId, triggerId, text, url.origin);
 		case '/help':
 			return handleHelp(env, teamId, triggerId);
 		default:

--- a/src/interactions/index.ts
+++ b/src/interactions/index.ts
@@ -214,7 +214,7 @@ async function handleStartPlanSubmission(
 	const checkinData = JSON.stringify({ time: now, label: planText, tag });
 	await env.STUDY_KV.put(`${teamId}:checkin:${userId}`, checkinData);
 
-	setUserStatus(env, teamId, userId, '집중 중', ':tomato:');
+	await setUserStatus(env, teamId, userId, '집중 중', ':computer:');
 
 	const todayKey = getTodayKey();
 	const todayList: string[] = JSON.parse((await env.STUDY_KV.get(`${teamId}:today:${todayKey}`)) || '[]');
@@ -564,7 +564,7 @@ async function handleAprilFoolsAction(
 	const checkinData = label ? JSON.stringify({ time: now, label }) : now.toString();
 	await env.STUDY_KV.put(`${teamId}:checkin:${userId}`, checkinData);
 
-	setUserStatus(env, teamId, userId, '집중 중', ':tomato:');
+	await setUserStatus(env, teamId, userId, '집중 중', ':computer:');
 
 	const todayKey = getTodayKey();
 	const todayList: string[] = JSON.parse((await env.STUDY_KV.get(`${teamId}:today:${todayKey}`)) || '[]');

--- a/src/interactions/index.ts
+++ b/src/interactions/index.ts
@@ -3,7 +3,7 @@
  * 모달 제출, 버튼 클릭 등 interactive component 이벤트 처리
  */
 
-import { postMessage, postMessageWithBlocks, updateMessage, getBotToken, postEphemeral } from '../utils/slack';
+import { postMessage, postMessageWithBlocks, updateMessage, getBotToken, postEphemeral, setUserStatus } from '../utils/slack';
 import { formatTime } from '../utils/format';
 import { getTodayKey } from '../utils/date';
 import { SESSION_TAGS, DEFAULT_TAG } from '../constants/messages';
@@ -99,6 +99,10 @@ async function handleBlockActions(payload: SlackInteractionPayload, env: Env): P
 
 	if (actionId === 'confirm_end_duration') {
 		return handleConfirmEndDuration(payload, env);
+	}
+
+	if (actionId === 'disconnect_status_sync') {
+		return handleDisconnectStatusSync(payload, env);
 	}
 
 	return new Response('', { status: 200 });
@@ -209,6 +213,8 @@ async function handleStartPlanSubmission(
 
 	const checkinData = JSON.stringify({ time: now, label: planText, tag });
 	await env.STUDY_KV.put(`${teamId}:checkin:${userId}`, checkinData);
+
+	setUserStatus(env, teamId, userId, '집중 중', ':tomato:');
 
 	const todayKey = getTodayKey();
 	const todayList: string[] = JSON.parse((await env.STUDY_KV.get(`${teamId}:today:${todayKey}`)) || '[]');
@@ -558,6 +564,8 @@ async function handleAprilFoolsAction(
 	const checkinData = label ? JSON.stringify({ time: now, label }) : now.toString();
 	await env.STUDY_KV.put(`${teamId}:checkin:${userId}`, checkinData);
 
+	setUserStatus(env, teamId, userId, '집중 중', ':tomato:');
+
 	const todayKey = getTodayKey();
 	const todayList: string[] = JSON.parse((await env.STUDY_KV.get(`${teamId}:today:${todayKey}`)) || '[]');
 	if (!todayList.includes(userId)) {
@@ -820,4 +828,16 @@ export function buildFinalChecklistBlocks(userId: string, startTime: number, ite
 	});
 
 	return blocks;
+}
+
+/** Status sync 연결 해제 */
+async function handleDisconnectStatusSync(payload: SlackInteractionPayload, env: Env): Promise<Response> {
+	const { user, channel } = payload;
+	await env.STUDY_KV.delete(`${user.team_id}:userToken:${user.id}`);
+
+	if (channel) {
+		await postEphemeral(env, user.team_id, channel.id, user.id, '🔌 Slack status 동기화가 해제되었어요. `/settings sync`로 다시 연결할 수 있어요.');
+	}
+
+	return new Response('', { status: 200 });
 }

--- a/src/pages/install/index.ts
+++ b/src/pages/install/index.ts
@@ -3,9 +3,10 @@
  * 외부 워크스페이스에서 집중요정을 설치할 수 있도록 지원
  */
 
-import { renderInstallPage, renderResultPage } from './render';
+import { renderInstallPage, renderResultPage, renderUserOAuthResultPage } from './render';
 
 const BOT_SCOPES = ['commands', 'chat:write', 'users:read', 'files:write', 'im:write'].join(',');
+const USER_SCOPES = 'users.profile:write';
 
 interface OAuthResponse {
 	ok: boolean;
@@ -15,6 +16,7 @@ interface OAuthResponse {
 	bot_user_id?: string;
 	app_id?: string;
 	team?: { name?: string; id: string };
+	authed_user?: { id: string; access_token?: string; scope?: string };
 	error?: string;
 }
 
@@ -79,5 +81,67 @@ export async function handleOAuthCallback(request: Request, env: Env): Promise<R
 	} catch (err) {
 		console.error('OAuth callback error:', err);
 		return htmlResponse(renderResultPage(false, '서버 오류가 발생했어요.'), 400);
+	}
+}
+
+/**
+ * 사용자 OAuth — Slack status 동기화 권한 요청
+ */
+export function handleUserOAuthInstall(request: Request, env: Env): Response {
+	const clientId = env.SLACK_CLIENT_ID;
+	if (!clientId) {
+		return new Response('OAuth is not configured', { status: 500 });
+	}
+
+	const origin = new URL(request.url).origin;
+	const redirectUri = `${origin}/slack/oauth/user-callback`;
+	const slackAuthUrl = `https://slack.com/oauth/v2/authorize?client_id=${clientId}&user_scope=${USER_SCOPES}&redirect_uri=${encodeURIComponent(redirectUri)}`;
+	return Response.redirect(slackAuthUrl, 302);
+}
+
+/**
+ * 사용자 OAuth 콜백 — user token 저장
+ */
+export async function handleUserOAuthCallback(request: Request, env: Env): Promise<Response> {
+	const url = new URL(request.url);
+	const code = url.searchParams.get('code');
+	const error = url.searchParams.get('error');
+
+	if (error) {
+		return htmlResponse(renderUserOAuthResultPage(false, '권한 연결이 취소되었어요.'), 400);
+	}
+
+	if (!code) {
+		return htmlResponse(renderUserOAuthResultPage(false, '인증 코드가 없어요.'), 400);
+	}
+
+	try {
+		const redirectUri = `${url.origin}/slack/oauth/user-callback`;
+		const response = await fetch('https://slack.com/api/oauth.v2.access', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: new URLSearchParams({
+				client_id: env.SLACK_CLIENT_ID,
+				client_secret: env.SLACK_CLIENT_SECRET,
+				code,
+				redirect_uri: redirectUri,
+			}),
+		});
+
+		const data = (await response.json()) as OAuthResponse;
+
+		if (!data.ok || !data.authed_user?.access_token || !data.authed_user?.id || !data.team?.id) {
+			console.error('User OAuth exchange failed:', data.error);
+			return htmlResponse(renderUserOAuthResultPage(false, `연결에 실패했어요: ${data.error || 'unknown error'}`), 400);
+		}
+
+		const teamId = data.team.id;
+		const userId = data.authed_user.id;
+		await env.STUDY_KV.put(`${teamId}:userToken:${userId}`, data.authed_user.access_token);
+
+		return htmlResponse(renderUserOAuthResultPage(true, 'Slack status 동기화가\n연결되었어요!'));
+	} catch (err) {
+		console.error('User OAuth callback error:', err);
+		return htmlResponse(renderUserOAuthResultPage(false, '서버 오류가 발생했어요.'), 400);
 	}
 }

--- a/src/pages/install/index.ts
+++ b/src/pages/install/index.ts
@@ -137,6 +137,7 @@ export async function handleUserOAuthCallback(request: Request, env: Env): Promi
 
 		const teamId = data.team.id;
 		const userId = data.authed_user.id;
+		console.log(`User OAuth success: team=${teamId}, user=${userId}`);
 		await env.STUDY_KV.put(`${teamId}:userToken:${userId}`, data.authed_user.access_token);
 
 		return htmlResponse(renderUserOAuthResultPage(true, 'Slack status 동기화가\n연결되었어요!'));

--- a/src/pages/install/render.ts
+++ b/src/pages/install/render.ts
@@ -132,6 +132,36 @@ export function renderInstallPage(slackAuthUrl: string): string {
 </html>`;
 }
 
+export function renderUserOAuthResultPage(success: boolean, message: string): string {
+	const emoji = success ? '🍅' : '😢';
+	const color = success ? '#34D399' : '#F87171';
+	const detail = success
+		? '<p style="color:#6B7280;margin-top:1rem;">이제 <code>/start</code>, <code>/end</code> 등 사용 시<br>Slack status가 자동으로 변경돼요.<br><br>이 탭을 닫고 Slack으로 돌아가세요!</p>'
+		: '<p style="color:#6B7280;margin-top:1rem;">다시 시도해주세요.</p>';
+
+	return `<!DOCTYPE html>
+<html lang="ko">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>${success ? '연결 완료' : '연결 실패'} | Focus Fairy</title>
+	<style>
+		body { margin:0; min-height:100vh; display:flex; align-items:center; justify-content:center; font-family:-apple-system,BlinkMacSystemFont,sans-serif; background:#F9FAFB; }
+		.card { text-align:center; background:white; padding:3rem; border-radius:1rem; box-shadow:0 4px 24px rgba(0,0,0,0.08); max-width:400px; }
+		.emoji { font-size:4rem; margin-bottom:1rem; }
+		h1 { color:${color}; white-space:pre-line; font-size:1.4rem; }
+	</style>
+</head>
+<body>
+	<div class="card">
+		<div class="emoji">${emoji}</div>
+		<h1>${message}</h1>
+		${detail}
+	</div>
+</body>
+</html>`;
+}
+
 export function renderResultPage(success: boolean, message: string): string {
 	const emojiHtml = success
 		? `<img src="${FAIRY_CONFETTI_IMG}" alt="confetti" style="width: 64px; height: 64px;">`

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -258,6 +258,58 @@ export async function getUserNames(env: Env, teamId: string, userIds: string[]):
 	return names;
 }
 
+/** KV에서 사용자 토큰(user token) 가져오기 */
+export async function getUserToken(env: Env, teamId: string, userId: string): Promise<string | null> {
+	return await env.STUDY_KV.get(`${teamId}:userToken:${userId}`);
+}
+
+/** 사용자의 Slack status 설정 (user token 필요) */
+export async function setUserStatus(
+	env: Env,
+	teamId: string,
+	userId: string,
+	statusText: string,
+	statusEmoji: string
+): Promise<boolean> {
+	const token = await getUserToken(env, teamId, userId);
+	if (!token) return false;
+
+	try {
+		const response = await fetch('https://slack.com/api/users.profile.set', {
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${token}`,
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				profile: {
+					status_text: statusText,
+					status_emoji: statusEmoji,
+					status_expiration: 0,
+				},
+			}),
+		});
+
+		const data = (await response.json()) as { ok: boolean; error?: string };
+		if (!data.ok) {
+			console.error('Failed to set user status:', data.error);
+			if (data.error === 'token_revoked' || data.error === 'invalid_auth') {
+				await env.STUDY_KV.delete(`${teamId}:userToken:${userId}`);
+			}
+			return false;
+		}
+		return true;
+	} catch (error) {
+		console.error('Failed to set user status:', error);
+		return false;
+	}
+}
+
+/** 사용자의 Slack status 초기화 */
+export async function clearUserStatus(env: Env, teamId: string, userId: string): Promise<boolean> {
+	return setUserStatus(env, teamId, userId, '', '');
+}
+
 /** Slack users.info API 응답 타입 */
 interface SlackUserResponse {
 	ok: boolean;

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -272,7 +272,10 @@ export async function setUserStatus(
 	statusEmoji: string
 ): Promise<boolean> {
 	const token = await getUserToken(env, teamId, userId);
-	if (!token) return false;
+	if (!token) {
+		console.log(`setUserStatus: no token for team=${teamId}, user=${userId}`);
+		return false;
+	}
 
 	try {
 		const response = await fetch('https://slack.com/api/users.profile.set', {


### PR DESCRIPTION
## Summary
- `/start`, `/pause`, `/resume`, `/end` 시 Slack status를 자동으로 변경 (🍅 집중 중 / ☕ 잠깐 자리비움 / 클리어)
- 사용자 개별 OAuth 동의(`users.profile:write`) 기반 opt-in 방식 — 기존 사용자 마찰 없음
- `/settings sync`로 연결 상태 확인, 연결/해제 관리

## 변경 내용
- `src/utils/slack.ts` — `getUserToken`, `setUserStatus`, `clearUserStatus` 함수 추가
- `src/pages/install/` — User OAuth 설치/콜백 엔드포인트 (`/slack/oauth/user-install`, `/slack/oauth/user-callback`)
- `src/commands/settings.ts` — `/settings sync` 서브커맨드
- `src/commands/start.ts`, `pause.ts`, `end.ts`, `src/interactions/index.ts` — 각 세션 이벤트에 status sync 연결

## 배포 전 필요 작업
- [ ] Slack 앱 설정에서 User Token Scopes에 `users.profile:write` 추가
- [ ] OAuth Redirect URL에 `https://{domain}/slack/oauth/user-callback` 추가

## Test plan
- [ ] `/settings sync` → 연결 안 됨 상태에서 OAuth 링크 표시 확인
- [ ] OAuth 플로우 완료 후 user token KV 저장 확인
- [ ] `/start` → Slack status "🍅 집중 중" 변경 확인
- [ ] `/pause` → "☕ 잠깐 자리비움" 변경 확인
- [ ] `/resume` → "🍅 집중 중" 복귀 확인
- [ ] `/end` → status 클리어 확인
- [ ] `/settings sync` → 연결 해제 후 status 미변경 확인
- [ ] OAuth 미연결 사용자는 기존과 동일하게 동작 확인

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)